### PR TITLE
feat(): basic sse mechanism that support sending to single, multiple and all clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Nomey Web App
+
 This is the official repository for the Nomey web app, built on the T3 Stack with custom extensions.
 
 ## Tech Stack
@@ -12,7 +13,7 @@ This is the official repository for the Nomey web app, built on the T3 Stack wit
 - [tolgee](https://tolgee.io/) - Translation Management
 - [Meilisearch](https://www.meilisearch.com/) - Full-text search
 - [Upstash](https://upstash.com/) Next compatible redis
-- [Qstash](https://upstash.com/docs/qstash) Next compatible queue handling 
+- [Qstash](https://upstash.com/docs/qstash) Next compatible queue handling
 - [Vitest](https://vitest.dev/) - Testing Framework
 
 ## Testing
@@ -42,6 +43,7 @@ npm run test
 ## Local Development
 
 ### Clone and Install
+
 ```bash
 git clone git@github.com:nomeyy/nomey-next.git
 cd nomey-next
@@ -58,11 +60,65 @@ You'll need to have `docker` installed locally. We advise running `./scripts/sta
 npm run dev
 ```
 
+## Server-Sent Events
+
+Real-time updates are handled through a tRPC subscription.
+
+```ts
+import { initSSE } from "@/lib/sse";
+
+initSSE();
+```
+
+This registers the demo module that periodically broadcasts mock events.
+
+Configure the tRPC client to use `httpSubscriptionLink`:
+
+```ts
+import { httpSubscriptionLink } from "@trpc/client";
+
+api.createClient({
+  links: [httpSubscriptionLink({ url: "/api/trpc" })],
+});
+
+const sub = api.sse.events.subscribe(undefined, {
+  onData(event) {
+    console.log("event:", event);
+  },
+});
+```
+
+Backend code or tRPC procedures can push updates to all connected clients using the helpers in `@/lib/sse`:
+
+```ts
+import { notifyAll, notifyMany } from "@/lib/sse";
+
+notifyAll("notification", { message: "Hello!" });
+
+notifyMany(["client-a", "client-b"], "notification", {
+  message: "To a few clients only",
+});
+
+// Customize how demo events target clients
+import { configureTargetSelector } from "@/lib/sse";
+configureTargetSelector((ids) => {
+  // Always broadcast
+  return ids;
+});
+
+// React to SSE connect/disconnect events
+import { registerModule } from "@/lib/sse";
+registerModule({
+  connect(id) {},
+  disconnect(id) {},
+});
+```
+
 > ⚠️ **Warning:** The T3 stack hard-enforces environment variables to provide type-safety. The project will not build without all environment variables in place. Contact a dev to get their variables to quickly get yourself up and running.
 
 ## Learn More
 
- - [Nomey Documentation (WIP)](https://nomey.mintlify.app/)
- - [Next Documentation](https://nextjs.org/docs)
- - [T3 Stack Documentation](https://create.t3.gg/en/usage/first-steps)
- - [Mux Documentation](https://www.mux.com/docs)
+- [Nomey Documentation (WIP)](https://nomey.mintlify.app/)
+- [Next Documentation](https://nextjs.org/docs)
+- [T3 Stack Documentation](https://create.t3.gg/en/usage/first-steps)
+- [Mux Documentation](https://www.mux.com/docs)

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import ClientComponent from "./temps/ClientComponent";
 import ServerComponent from "./temps/ServerComponent";
+import { SSEDemo } from "@/features/sse";
 
 const LandingPage = () => (
   <>
@@ -9,6 +10,7 @@ const LandingPage = () => (
     </h1>
 
     <div className="max-w-[600px] space-y-5 text-left">
+      <SSEDemo />
       <ClientComponent />
 
       <ServerComponent />

--- a/src/features/sse/components/SSEDemo.tsx
+++ b/src/features/sse/components/SSEDemo.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/trpc/react";
+import { Button } from "@/shared/components/ui/button";
+
+const SSEDemo = () => {
+  const [latest, setLatest] = useState<string>("none");
+  const [connected, setConnected] = useState(false);
+
+  api.sse.events.useSubscription(undefined, {
+    enabled: connected,
+    onData(event) {
+      if (event.event === "mock") {
+        setLatest(JSON.stringify(event, null, 2));
+      }
+    },
+  });
+
+  const toggleConnection = () => {
+    setConnected((prev) => {
+      if (prev) setLatest("none");
+      return !prev;
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <Button onClick={toggleConnection}>
+        {connected ? "Disconnect from SSE" : "Connect to SSE"}
+      </Button>
+      <pre className="whitespace-pre-wrap">{latest}</pre>
+    </div>
+  );
+};
+
+export default SSEDemo;

--- a/src/features/sse/index.ts
+++ b/src/features/sse/index.ts
@@ -1,0 +1,2 @@
+export { sseRouter } from "./trpc/router";
+export { default as SSEDemo } from "./components/SSEDemo";

--- a/src/features/sse/trpc/router.ts
+++ b/src/features/sse/trpc/router.ts
@@ -1,0 +1,12 @@
+import { createTRPCRouter, publicProcedure } from "@/lib/trpc";
+import { z } from "zod";
+import { sseManager } from "@/lib/sse";
+
+export const sseRouter = createTRPCRouter({
+  events: publicProcedure
+    .input(z.object({ id: z.string().optional() }).optional())
+    .subscription(({ input }) => {
+      const clientId = input?.id ?? crypto.randomUUID();
+      return sseManager.subscribe(clientId);
+    }),
+});

--- a/src/lib/sse/index.ts
+++ b/src/lib/sse/index.ts
@@ -1,0 +1,4 @@
+export { sseManager } from "./manager";
+export { notifyAll, notifyClient } from "./notify";
+export * from "./mock";
+export { initSSE } from "./init";

--- a/src/lib/sse/init.ts
+++ b/src/lib/sse/init.ts
@@ -1,0 +1,13 @@
+import { setupMockEvents } from "./mock";
+
+// TODO: make this better so it's not just in memory
+let initialized = false;
+
+/**
+ * Register and start default SSE modules. Subsequent calls have no effect.
+ */
+export function initSSE() {
+  if (initialized) return;
+  initialized = true;
+  setupMockEvents();
+}

--- a/src/lib/sse/manager.ts
+++ b/src/lib/sse/manager.ts
@@ -1,0 +1,196 @@
+import { observable } from "@trpc/server/observable";
+import { createServiceContext } from "@/utils/service-utils";
+
+const { log } = createServiceContext("SSEManager");
+
+/**
+ * Represents a single SSE event with a name and data payload.
+ */
+export interface SSEEvent {
+  event: string;
+  data: unknown;
+}
+
+/**
+ * Function signature for sending an SSE event to a client.
+ */
+export type SSESendFn = (event: string, data: unknown) => void;
+
+/**
+ * Represents a connected SSE client.
+ */
+export interface SSEClient {
+  id: string;
+  send: SSESendFn;
+}
+
+/**
+ * Basic in-memory SSE manager used to broadcast events to connected clients.
+ * Handles client registration, event broadcasting, and heartbeats.
+ */
+type EventName = "connect" | "disconnect";
+type Listener = (clientId: string) => void;
+
+class SSEManager {
+  // Map of client IDs to SSEClient objects
+  private clients = new Map<string, SSEClient>();
+  // Heartbeat timer ID
+  private heartbeatId: NodeJS.Timeout | null = null;
+  // Event listeners for connect/disconnect
+  private listeners: Record<EventName, Set<Listener>> = {
+    connect: new Set(),
+    disconnect: new Set(),
+  };
+
+  /**
+   * @param heartbeatIntervalMs Interval for sending heartbeat pings (ms)
+   */
+  constructor(private heartbeatIntervalMs = 30000) {}
+
+  /**
+   * Returns the number of currently connected clients.
+   */
+  getClientCount() {
+    return this.clients.size;
+  }
+
+  /**
+   * Returns an array of all connected client IDs.
+   */
+  getClientIds() {
+    return Array.from(this.clients.keys());
+  }
+
+  /**
+   * Starts sending heartbeat pings to all clients at the configured interval.
+   */
+  startHeartbeat() {
+    this.heartbeatId ??= setInterval(() => {
+      for (const client of this.clients.values()) {
+        try {
+          client.send("ping", { ts: Date.now() });
+        } catch (err) {
+          log.error("heartbeat failed", err, { clientId: client.id });
+        }
+      }
+    }, this.heartbeatIntervalMs);
+  }
+
+  /**
+   * Stops the heartbeat timer if running.
+   */
+  stopHeartbeat() {
+    if (this.heartbeatId) {
+      clearInterval(this.heartbeatId);
+      this.heartbeatId = null;
+    }
+  }
+
+  /**
+   * Calls all listeners for a given event type.
+   */
+  private emit(event: EventName, clientId: string) {
+    for (const cb of this.listeners[event]) {
+      try {
+        cb(clientId);
+      } catch (err) {
+        log.error("listener error", err, { event, clientId });
+      }
+    }
+  }
+
+  /**
+   * Registers a listener for connect or disconnect events.
+   * Returns an unsubscribe function.
+   */
+  on(event: EventName, listener: Listener) {
+    this.listeners[event].add(listener);
+    return () => this.listeners[event].delete(listener);
+  }
+
+  /**
+   * Adds a new client to the manager and starts heartbeat if first client.
+   */
+  addClient(client: SSEClient) {
+    this.clients.set(client.id, client);
+    log.info("client connected", { clientId: client.id });
+    if (this.clients.size === 1) {
+      this.startHeartbeat();
+    }
+    this.emit("connect", client.id);
+  }
+
+  /**
+   * Removes a client by ID and stops heartbeat if no clients remain.
+   */
+  removeClient(clientId: string) {
+    this.clients.delete(clientId);
+    log.info("client disconnected", { clientId });
+    if (this.clients.size === 0) {
+      this.stopHeartbeat();
+    }
+    this.emit("disconnect", clientId);
+  }
+
+  /**
+   * Returns an observable for a client subscription, handling connect/disconnect.
+   */
+  subscribe(clientId: string) {
+    return observable<SSEEvent>((emit) => {
+      // Create a send function for this client
+      const send: SSESendFn = (event, data) => emit.next({ event, data });
+      const client: SSEClient = { id: clientId, send };
+      this.addClient(client);
+      log.debug("subscribe", { clientId });
+      // Notify client of successful connection
+      send("connected", { id: clientId });
+
+      // Cleanup on unsubscribe
+      return () => {
+        this.removeClient(clientId);
+        log.debug("unsubscribe", { clientId });
+      };
+    });
+  }
+
+  /**
+   * Sends an event to a specific client by ID.
+   */
+  send(clientId: string, event: string, data: unknown) {
+    const client = this.clients.get(clientId);
+    if (!client) return;
+    try {
+      client.send(event, data);
+    } catch (err) {
+      log.error("send failed", err, { clientId, event });
+    }
+  }
+
+  /**
+   * Sends an event to multiple clients by their IDs.
+   */
+  sendMany(clientIds: string[], event: string, data: unknown) {
+    for (const id of clientIds) {
+      this.send(id, event, data);
+    }
+  }
+
+  /**
+   * Broadcasts an event to all connected clients.
+   */
+  broadcast(event: string, data: unknown) {
+    log.info("broadcast", { event, clientCount: this.clients.size });
+    for (const client of this.clients.values()) {
+      try {
+        client.send(event, data);
+      } catch (err) {
+        log.error("broadcast failed", err, { clientId: client.id, event });
+      }
+    }
+  }
+}
+
+/**
+ * Singleton instance of the SSEManager for use throughout the app.
+ */
+export const sseManager = new SSEManager();

--- a/src/lib/sse/mock.ts
+++ b/src/lib/sse/mock.ts
@@ -1,0 +1,80 @@
+import { sseManager } from "./manager";
+import { registerModule } from "./register";
+import { notifyAll, notifyClient } from "./notify";
+
+export type TargetSelector = (clientIds: string[]) => string[];
+
+let selectTargets: TargetSelector = (clientIds) => {
+  if (clientIds.length <= 1 || Math.random() < 0.5) {
+    return clientIds; // broadcast
+  }
+  // send to a random client
+  // TODO: this can be changed to send to a specific clientId (userId / sessionId) as well
+  const id = clientIds[Math.floor(Math.random() * clientIds.length)];
+  return id ? [id] : [];
+};
+
+export function configureTargetSelector(selector: TargetSelector) {
+  selectTargets = selector;
+}
+
+let timeout: NodeJS.Timeout | null = null;
+
+const MIN_DELAY_MS = 1 * 1000; // 1 second
+const MAX_DELAY_MS = 3 * 1000; // 3 seconds
+
+const schedule = () => {
+  // random delay from MIN_DELAY_MS to MAX_DELAY_MS
+  const delay =
+    Math.floor(Math.random() * (MAX_DELAY_MS - MIN_DELAY_MS + 1)) +
+    MIN_DELAY_MS;
+  timeout = setTimeout(() => {
+    const ids = sseManager.getClientIds();
+    if (ids.length === 0) {
+      stopMockEvents();
+      return;
+    }
+    const targets = selectTargets(ids);
+    const message = { text: `Random message at ${new Date().toISOString()}` };
+
+    // depending on randomly aggrecated targets, either broadcast to all
+    // or send to a specific target id
+    if (targets.length === ids.length) {
+      notifyAll("mock", message);
+    } else {
+      for (const id of targets) {
+        notifyClient(id, "mock", { ...message, targetId: id });
+      }
+    }
+    schedule();
+  }, delay);
+};
+
+export const startMockEvents = () => {
+  if (!timeout && sseManager.getClientCount() > 0) {
+    schedule();
+  }
+};
+
+export const stopMockEvents = () => {
+  if (timeout) {
+    clearTimeout(timeout);
+    timeout = null;
+  }
+};
+
+/** Register listeners on the SSE manager so mock events
+ * automatically start when clients connect and stop when none remain. */
+export const setupMockEvents = () => {
+  registerModule({
+    connect: startMockEvents,
+    disconnect: () => {
+      if (sseManager.getClientCount() === 0) {
+        stopMockEvents();
+      }
+    },
+  });
+  if (sseManager.getClientCount() > 0) {
+    startMockEvents();
+  }
+};

--- a/src/lib/sse/notify.ts
+++ b/src/lib/sse/notify.ts
@@ -1,0 +1,13 @@
+import { sseManager } from "./manager";
+
+export const notifyAll = (event: string, data: unknown) => {
+  sseManager.broadcast(event, data);
+};
+
+export const notifyClient = (
+  clientId: string,
+  event: string,
+  data: unknown,
+) => {
+  sseManager.send(clientId, event, data);
+};

--- a/src/lib/sse/register.ts
+++ b/src/lib/sse/register.ts
@@ -1,0 +1,19 @@
+export interface SSEModule {
+  connect: (clientId: string) => void;
+  disconnect: (clientId: string) => void;
+}
+
+import { sseManager } from "./manager";
+
+/**
+ * Register a module to react to SSE connection lifecycle events.
+ * Returns a cleanup function to remove listeners.
+ */
+export function registerModule(mod: SSEModule) {
+  const offConnect = sseManager.on("connect", mod.connect);
+  const offDisconnect = sseManager.on("disconnect", mod.disconnect);
+  return () => {
+    offConnect();
+    offDisconnect();
+  };
+}

--- a/src/lib/trpc/index.ts
+++ b/src/lib/trpc/index.ts
@@ -11,6 +11,7 @@ import superjson from "superjson";
 import { ZodError } from "zod";
 import { db } from "@/lib/db";
 import { getSession } from "@/features/auth";
+import { sseManager, initSSE } from "@/lib/sse";
 /**
  * 1. CONTEXT
  *
@@ -24,10 +25,12 @@ import { getSession } from "@/features/auth";
  * @see https://trpc.io/docs/server/context
  */
 export const createTRPCContext = async (opts: { headers: Headers }) => {
+  initSSE();
   const session = await getSession();
 
   return {
     db,
+    sse: sseManager,
     session,
     ...opts,
   };

--- a/src/lib/trpc/root.ts
+++ b/src/lib/trpc/root.ts
@@ -1,5 +1,6 @@
 import { createCallerFactory, createTRPCRouter } from "@/lib/trpc";
 import { searchRouter } from "@/features/search";
+import { sseRouter } from "@/features/sse";
 
 /**
  * This is the primary router for your server.
@@ -8,6 +9,7 @@ import { searchRouter } from "@/features/search";
  */
 export const appRouter = createTRPCRouter({
   search: searchRouter,
+  sse: sseRouter,
 });
 
 // export type definition of API

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
-import { httpBatchStreamLink, loggerLink } from "@trpc/client";
+import {
+  httpBatchStreamLink,
+  loggerLink,
+  splitLink,
+  httpSubscriptionLink,
+} from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
@@ -49,14 +54,21 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
             process.env.NODE_ENV === "development" ||
             (op.direction === "down" && op.result instanceof Error),
         }),
-        httpBatchStreamLink({
-          transformer: SuperJSON,
-          url: getBaseUrl() + "/api/trpc",
-          headers: () => {
-            const headers = new Headers();
-            headers.set("x-trpc-source", "nextjs-react");
-            return headers;
-          },
+        splitLink({
+          condition: (op) => op.type === "subscription",
+          true: httpSubscriptionLink({
+            transformer: SuperJSON,
+            url: getBaseUrl() + "/api/trpc",
+          }),
+          false: httpBatchStreamLink({
+            transformer: SuperJSON,
+            url: getBaseUrl() + "/api/trpc",
+            headers: () => {
+              const headers = new Headers();
+              headers.set("x-trpc-source", "nextjs-react");
+              return headers;
+            },
+          }),
         }),
       ],
     }),


### PR DESCRIPTION
Demo + Walkthrough:
https://www.loom.com/share/dc59d2f9db9f4999b6b5a8be46de8f5e?sid=e9d2e943-2372-4b4c-bdec-a732041cd057

Description:
- added sse event to trpc
- added a mock sse model to demo sse events being sent from BE to FE
- updated the client trpc client with splitLink and httpSubscriptionLink to support sse events
- updated README to show how to create new modules and register the modules to send sse events

AC:
- [x] SSE endpoint implemented to accept client connections and maintain open streams.
- [x] Clients can subscribe and receive events pushed from the server.
- [x] Server code can send arbitrary named events with JSON payloads to individual or multiple clients.
- [x] Heartbeat/ping mechanism in place to keep connections alive.
- [x] Proper handling of client disconnects with cleanup of server resources.
- [x] Error handling and logging included.
- [x] Well-documented usage for backend integration.