### PR TITLE
Feat: Add SSE implementation with broadcasting support

### DIFF
--- a/src/app/(public)/SSEListener.tsx
+++ b/src/app/(public)/SSEListener.tsx
@@ -1,0 +1,67 @@
+'use client';
+import { useState } from 'react';
+
+const SSEListener = ({ clientId }: { clientId: string }) => {
+    const [latestMessage, setLatestMessage] = useState<string | null>(null);
+    const [connected, setConnected] = useState<boolean>(false);
+    const [eventSource, setEventSource] = useState<EventSource | null>(null);
+    const [err, setErr] = useState<any>(null);
+
+    const handleConnect = () => {
+        if (!clientId || eventSource) return;
+
+        const es = new EventSource(`/api/sse?clientId=${clientId}`);
+
+        es.onopen = () => {
+            console.log('✅ Connected to SSE server');
+            setConnected(true);
+        };
+
+        es.onerror = (err) => {
+            console.error('❌ SSE error:', err);
+            setErr(JSON.stringify(err));
+            // es.close();
+            // setConnected(false);
+            // setEventSource(null);
+        };
+
+        es.addEventListener('connected', (event) => {
+            const data = JSON.parse(event.data);
+            console.log('🟢 Connected event:', data);
+        });
+
+        es.addEventListener('notification', (event) => {
+            const data = JSON.parse(event.data);
+            console.log('🔔 Notification event:', data);
+            setLatestMessage(data.message);
+        });
+
+        setEventSource(es);
+    };
+
+    const handleDisconnect = () => {
+        if (eventSource) {
+            eventSource.close();
+            setConnected(false);
+            setEventSource(null);
+            console.log('🛑 Disconnected from SSE');
+        }
+    };
+
+    return (
+        <div>
+            <button
+                onClick={connected ? handleDisconnect : handleConnect}
+                className="bg-blue-500 text-white px-4 py-2 rounded mb-4"
+            >
+                {connected ? 'Disconnect' : 'Connect'}
+            </button>
+
+            <h2>📩 Latest SSE Message:</h2>
+            <p>{latestMessage || 'Waiting for messages...'}</p>
+            <p>Error : {err}</p>
+        </div>
+    );
+};
+
+export default SSEListener;

--- a/src/app/(public)/SSEListener.tsx
+++ b/src/app/(public)/SSEListener.tsx
@@ -2,49 +2,51 @@
 import { useState } from 'react';
 
 const SSEListener = ({ clientId }: { clientId: string }) => {
-    const [latestMessage, setLatestMessage] = useState<string | null>(null);
-    const [connected, setConnected] = useState<boolean>(false);
-    const [eventSource, setEventSource] = useState<EventSource | null>(null);
-    const [err, setErr] = useState<any>(null);
+    const [latestMessage, setLatestMessage] = useState<string | null>(null); // Holds the latest message received
+    const [connected, setConnected] = useState<boolean>(false); // Indicates connection status
+    const [eventSource, setEventSource] = useState<EventSource | null>(null); // Holds the EventSource instance
+    const [err, setErr] = useState<any>(null); // Stores any error from the SSE connection
 
+    // Establishes a connection to the SSE server
     const handleConnect = () => {
         if (!clientId || eventSource) return;
 
         const es = new EventSource(`/api/sse?clientId=${clientId}`);
 
+        // Called when the connection to the server is successfully established
         es.onopen = () => {
-            console.log('✅ Connected to SSE server');
+            console.log('Connected to SSE server');
             setConnected(true);
         };
 
+        // Handles connection errors
         es.onerror = (err) => {
-            console.error('❌ SSE error:', err);
             setErr(JSON.stringify(err));
-            // es.close();
-            // setConnected(false);
-            // setEventSource(null);
         };
 
+        // Handles initial connection confirmation event
         es.addEventListener('connected', (event) => {
             const data = JSON.parse(event.data);
-            console.log('🟢 Connected event:', data);
+            console.log('Connected event:', data);
         });
 
+        // Handles custom "notification" events from the server
         es.addEventListener('notification', (event) => {
             const data = JSON.parse(event.data);
-            console.log('🔔 Notification event:', data);
+            console.log('Notification event:', data);
             setLatestMessage(data.message);
         });
 
         setEventSource(es);
     };
 
+    // Closes the SSE connection and resets relevant state
     const handleDisconnect = () => {
         if (eventSource) {
             eventSource.close();
             setConnected(false);
             setEventSource(null);
-            console.log('🛑 Disconnected from SSE');
+            console.log('Disconnected from SSE');
         }
     };
 
@@ -54,12 +56,12 @@ const SSEListener = ({ clientId }: { clientId: string }) => {
                 onClick={connected ? handleDisconnect : handleConnect}
                 className="bg-blue-500 text-white px-4 py-2 rounded mb-4"
             >
-                {connected ? 'Disconnect' : 'Connect'}
+                {connected ? 'Disconnect' : 'Initialize connection'}
             </button>
 
-            <h2>📩 Latest SSE Message:</h2>
+            <h2>Latest SSE Message:</h2>
             <p>{latestMessage || 'Waiting for messages...'}</p>
-            <p>Error : {err}</p>
+            <p>Error: {err}</p>
         </div>
     );
 };

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,7 +1,9 @@
 import Link from "next/link";
 import ClientComponent from "./temps/ClientComponent";
 import ServerComponent from "./temps/ServerComponent";
+import SSEListener from "./SSEListener";
 
+const clientId = 'user-123';
 const LandingPage = () => (
   <>
     <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem]">
@@ -10,8 +12,13 @@ const LandingPage = () => (
 
     <div className="max-w-[600px] space-y-5 text-left">
       <ClientComponent />
-
       <ServerComponent />
+
+      <div>
+        <h1>🚀 SSE TEST</h1>
+        <SSEListener clientId={clientId} />
+      </div>
+
     </div>
 
     <Link

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -15,7 +15,7 @@ const LandingPage = () => (
       <ServerComponent />
 
       <div>
-        <h1>🚀 SSE TEST</h1>
+        <h1>SSE TEST</h1>
         <SSEListener clientId={clientId} />
       </div>
 

--- a/src/app/api/sendMessage/route.ts
+++ b/src/app/api/sendMessage/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import sseManager from '@/lib/sseManager';
+
+// Handles sending events to a specific client or all clients
+export async function POST(req: NextRequest) {
+    const body = await req.json();
+    const { clientId, event, payload, broadcast } = body;
+
+    // Validate required fields
+    if (!event || !payload) {
+        return NextResponse.json({ error: 'Missing event or payload' }, { status: 400 });
+    }
+
+    if (broadcast || clientId === '*') {
+        // Broadcast to all clients
+        console.log('Broadcasting event:', event);
+        sseManager.broadcast(event, payload);
+    } else if (clientId) {
+        // Send to specific client
+        console.log('Sending to client:', clientId);
+        sseManager.send(clientId, event, payload);
+    }
+
+    return NextResponse.json({ success: true });
+}

--- a/src/app/api/sse/route.ts
+++ b/src/app/api/sse/route.ts
@@ -1,0 +1,71 @@
+// app/api/sse/route.ts
+import { NextRequest } from 'next/server';
+import sseManager from '@/lib/sseManager';
+
+export const runtime = 'nodejs'; // Ensures the route runs in a Node.js environment for stream support
+
+// Handles GET requests for establishing SSE connections
+export async function GET(req: NextRequest) {
+    const { searchParams } = new URL(req.url);
+    const clientId = searchParams.get('clientId');
+
+    // Validate clientId
+    if (!clientId) {
+        return new Response('Missing clientId', { status: 400 });
+    }
+
+    const encoder = new TextEncoder();
+
+    // Create a ReadableStream to push SSE data
+    const stream = new ReadableStream({
+        start(controller) {
+            // Method to send data to the client
+            const write = (data: string) => {
+                try {
+                    controller.enqueue(encoder.encode(data));
+                } catch (err) {
+                    console.warn(`Failed to write to stream for client ${clientId}:`, err);
+                }
+            };
+
+            // Response object used by SSEManager
+            const res = {
+                write,
+                end: () => {
+                    try {
+                        controller.close();
+                    } catch (err) {
+                        console.log(`Tried to close already closed stream for client: ${clientId}`, err);
+                    }
+                },
+            };
+
+            // Register the client with the SSEManager
+            sseManager.addClient(clientId, res);
+
+            // Send initial connected event
+            write(`event: connected\ndata: ${JSON.stringify({ clientId })}\n\n`);
+
+            // Periodic keep-alive to prevent connection from being closed by proxies
+            const keepAlive = setInterval(() => {
+                write(`: keep-alive\n\n`);
+            }, 15000);
+
+            // Cleanup on client disconnect
+            req.signal.addEventListener('abort', () => {
+                clearInterval(keepAlive);
+                sseManager.removeClient(clientId);
+            });
+        },
+    });
+
+    // Return the stream as a response with appropriate SSE headers
+    return new Response(stream, {
+        headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache, no-transform',
+            'Connection': 'keep-alive',
+            'Access-Control-Allow-Origin': '*',
+        },
+    });
+}

--- a/src/lib/sseManager.ts
+++ b/src/lib/sseManager.ts
@@ -1,12 +1,14 @@
-
 type ClientResponse = {
     write: (data: string) => void;
     end: () => void;
 };
 
+// SSEManager handles server-sent events for multiple connected clients
 class SSEManager {
+    // Stores connected clients with their corresponding response object
     private clients: Map<string, ClientResponse> = new Map();
 
+    // Adds a new client and immediately sends a "connected" event
     addClient(clientId: string, res: ClientResponse) {
         console.log("Add client : ", clientId);
         this.clients.set(clientId, res);
@@ -14,43 +16,52 @@ class SSEManager {
         console.log(`SSE client connected: ${clientId}`);
     }
 
+    // Removes a client and closes the connection
     removeClient(clientId: string) {
         const res = this.clients.get(clientId);
         if (res) {
-            res.end();
-            this.clients.delete(clientId);
+            res.end(); // Ends the SSE connection
+            this.clients.delete(clientId); // Removes client from the map
             console.log(`SSE client disconnected: ${clientId}`);
         }
     }
 
-    // send(clientId: string, event: string, data: any) {
-    //     const res = this.clients.get(clientId);
-
-    //     if (res) {
-    //         res.write(`event: ${event}\n`);
-    //         res.write(`data: ${JSON.stringify(data)}\n\n`);
-    //     }
-    // }
+    // Sends a specific event with data to the given client
     send(clientId: string, event: string, data: any) {
         const res = this.clients.get(clientId);
 
         if (res) {
             const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-            res.write(payload); // 👈 Single write flushes it properly
+            res.write(payload); // Sends the event to the client
         }
     }
 
+    // Sends a message to all connected clients
+    broadcast(event: string, data: any) {
+        const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+        for (const [clientId, res] of this.clients.entries()) {
+            try {
+                res.write(payload);
+            } catch (err) {
+                console.warn(`Failed to send broadcast to client ${clientId}:`, err);
+            }
+        }
+    }
+
+    // Periodically sends a ping message to keep the SSE connection alive
     ping(interval = 10000) {
         setInterval(() => {
             console.log(this.clients);
             for (const res of this.clients.values()) {
-                res.write(`: ping...\n\n`);
+                res.write(`: ping...\n\n`); // Comment line in SSE, used as heartbeat
             }
         }, interval);
     }
 }
 
+// Creates a singleton instance of SSEManager and starts the ping
 const sseManager = new SSEManager();
-sseManager.ping(); // start ping immediately
+sseManager.ping(); // Start sending heartbeat pings
 
 export default sseManager;

--- a/src/lib/sseManager.ts
+++ b/src/lib/sseManager.ts
@@ -1,0 +1,56 @@
+
+type ClientResponse = {
+    write: (data: string) => void;
+    end: () => void;
+};
+
+class SSEManager {
+    private clients: Map<string, ClientResponse> = new Map();
+
+    addClient(clientId: string, res: ClientResponse) {
+        console.log("Add client : ", clientId);
+        this.clients.set(clientId, res);
+        this.send(clientId, 'connected', { clientId });
+        console.log(`SSE client connected: ${clientId}`);
+    }
+
+    removeClient(clientId: string) {
+        const res = this.clients.get(clientId);
+        if (res) {
+            res.end();
+            this.clients.delete(clientId);
+            console.log(`SSE client disconnected: ${clientId}`);
+        }
+    }
+
+    // send(clientId: string, event: string, data: any) {
+    //     const res = this.clients.get(clientId);
+
+    //     if (res) {
+    //         res.write(`event: ${event}\n`);
+    //         res.write(`data: ${JSON.stringify(data)}\n\n`);
+    //     }
+    // }
+    send(clientId: string, event: string, data: any) {
+        const res = this.clients.get(clientId);
+
+        if (res) {
+            const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+            res.write(payload); // 👈 Single write flushes it properly
+        }
+    }
+
+    ping(interval = 10000) {
+        setInterval(() => {
+            console.log(this.clients);
+            for (const res of this.clients.values()) {
+                res.write(`: ping...\n\n`);
+            }
+        }, interval);
+    }
+}
+
+const sseManager = new SSEManager();
+sseManager.ping(); // start ping immediately
+
+export default sseManager;


### PR DESCRIPTION
```
**Summary**
This PR implements a robust SSE (Server-Sent Events) system that supports:
- Persistent client connections via SSE
- Tracking active clients by clientId
- Sending named events with payloads to:
- A specific client
- All connected clients (broadcast)
- Automatic heartbeat/ping to prevent idle timeouts
- Proper cleanup on client disconnect or stream errors
- A clean API (/api/sendMessage) to send messages from any backend logic

**Changes Overview**
Backend
_/app/api/sse/route.ts_
- Handles incoming SSE connections per clientId
- Sends initial connected event
- Includes keep-alive heartbeat (: keep-alive)
- Disconnect listener via req.signal.abort

_/app/api/sendMessage/route.ts_
POST API to send messages to a specific client (clientId) or broadcast to all clients
Accepts: event, payload, and optional clientId

_/lib/sseManager.ts_
In-memory management of active clients

**Testing**
curl -X POST http://localhost:3000/api/sendMessage \
  -H "Content-Type: application/json" \
  -d '{"clientId":"abc", "event":"notification", "payload":{"message":"Hello"}}'

```


https://github.com/user-attachments/assets/fe388348-3cd2-45df-a037-638c359e394e

Note:
- SSE connection error handling was adjusted to avoid client-side disconnect on intermittent errors.
- Broadcast support was added to `sseManager`.
- Tested using curl and frontend button triggers.
