### PR TITLE
feat: adding sse-manager changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ tolgee.config.yaml
 
 # editor directories
 .vscode
+temp_auto_push.bat
+temp_interactive_push.bat
+branch_structure.json

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,4 @@
+
 export default {
   plugins: {
     "@tailwindcss/postcss": {},

--- a/src/app/(protected)/sse-demo/error.tsx
+++ b/src/app/(protected)/sse-demo/error.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import ErrorBoundary from "@/shared/components/ErrorBoundary";
+
+const Error = ({ error }: { error: Error & { digest?: string } }) =>
+  ErrorBoundary({ error });
+
+export default Error;

--- a/src/app/(protected)/sse-demo/page.tsx
+++ b/src/app/(protected)/sse-demo/page.tsx
@@ -1,0 +1,5 @@
+import { SSEDemo } from "@/features/sse";
+
+export default function SSEDemoPage() {
+  return <SSEDemo />;
+}

--- a/src/app/api/sse/route.ts
+++ b/src/app/api/sse/route.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
+
+import { type NextRequest } from "next/server";
+import { getSession } from "@/features/auth";
+import { sseManager } from "../../../features/sse/services/sse-manager";
+import { sseService } from "../../../features/sse/services/sse-service";
+
+/**
+ * SSE endpoint for establishing real-time connections
+ *
+ * This endpoint:
+ * 1. Validates user authentication
+ * 2. Creates a streaming response
+ * 3. Registers the connection with the SSE manager
+ * 4. Sends a welcome message
+ * 5. Handles connection cleanup on close
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const userId = session.user.id;
+    const userName = session.user.name || undefined;
+
+    // Extracting client metadata
+    const userAgent = request.headers.get("user-agent") || undefined;
+    const forwarded = request.headers.get("x-forwarded-for");
+    const clientIp = forwarded
+      ? forwarded.split(",")[0]?.trim()
+      : request.headers.get("x-real-ip") || undefined;
+
+    console.log(`[SSE] New connection attempt from user ${userId}`);
+
+    // Create a ReadableStream for SSE
+    const stream = new ReadableStream({
+      start(controller) {
+        // const writer = controller;
+        // const encoder = new TextEncoder();
+
+        const sseWriter = {
+          write: async (data: Uint8Array) => {
+            try {
+              controller.enqueue(data);
+            } catch (error) {
+              console.error("[SSE] Writer error:", error);
+              throw error;
+            }
+          },
+          close: () => {
+            try {
+              controller.close();
+            } catch (error) {
+              console.warn("[SSE] Controller already closed:", error);
+            }
+          },
+        } as WritableStreamDefaultWriter<Uint8Array>;
+
+        // Register the connection
+        const connectionId = sseManager.addConnection(userId, sseWriter, {
+          userAgent,
+          clientIp,
+        });
+
+        console.log(`[SSE] Connection established: ${connectionId}`);
+
+        // Send welcome message
+        sseService.sendWelcomeMessage(userId, userName).catch((error) => {
+          console.error("[SSE] Failed to send welcome message:", error);
+        });
+
+        // Store connection ID for cleanup
+        interface SseRequest extends NextRequest {
+          _sseConnectionId?: string;
+        }
+        (request as SseRequest)._sseConnectionId = connectionId;
+      },
+
+      cancel(reason) {
+        console.log(`[SSE] Connection cancelled:`, reason);
+        interface SseRequest extends NextRequest {
+          _sseConnectionId?: string;
+        }
+        const connectionId = (request as SseRequest)._sseConnectionId;
+        if (connectionId) {
+          sseManager.removeConnection(connectionId);
+        }
+      },
+    });
+
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Cache-Control",
+        "Access-Control-Allow-Credentials": "true",
+        // Disable buffering for Nginx and other proxies
+        "X-Accel-Buffering": "no",
+        // Additional headers for better SSE support
+        "Transfer-Encoding": "chunked",
+      },
+    });
+  } catch (error) {
+    console.error("[SSE] Error establishing connection:", error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}
+
+/**
+ * Handle preflight requests for CORS
+ */
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "Content-Type, Authorization, Cache-Control",
+      "Access-Control-Allow-Credentials": "true",
+    },
+  });
+}

--- a/src/app/api/sse/stats/route.ts
+++ b/src/app/api/sse/stats/route.ts
@@ -1,0 +1,27 @@
+import { type NextRequest } from "next/server";
+import { getSession } from "@/features/auth";
+import { sseService } from "@/features/sse";
+
+/**
+ * GET /api/sse/stats
+ * Get SSE connection statistics (protected endpoint)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session?.user) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const stats = sseService.getStats();
+
+    return Response.json({
+      success: true,
+      data: stats,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("[SSE Stats] Error:", error);
+    return Response.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -31,6 +31,7 @@ export const paths = {
   landingPage: "/",
   homePage: "/home",
   reelsUploadPage: "/reels/upload",
+  sseDemoPage: "/sse-demo",
 } as const;
 
 // ⚠️ DEFINE METADATA FOR NEW ROUTES HERE ⚠️
@@ -49,6 +50,11 @@ export const routes: Record<keyof typeof paths, RouteData> = {
   reelsUploadPage: {
     name: "Reels Upload Page",
     path: paths.reelsUploadPage,
+    accessType: "protected",
+  },
+  sseDemoPage: {
+    name: "SSE Demo Page",
+    path: paths.sseDemoPage,
     accessType: "protected",
   },
 };

--- a/src/features/auth/client.ts
+++ b/src/features/auth/client.ts
@@ -1,0 +1,19 @@
+/**
+ * Client-side only exports for the authentication module.
+ * This file should be imported to use auth functionality in client components.
+ */
+
+// Hook for accessing the current authentication session state in client components
+export { useSession } from "./hooks/useSession";
+
+// Provider component that makes authentication session available to the component tree
+export { SessionProvider } from "./contexts/SessionContext";
+
+// Provider for public routes that don't require full authentication context
+export { PublicSessionProvider } from "./contexts/PublicSessionContext";
+
+// Public types that client components may need
+export * from "./types/public";
+
+// Client-side utility functions for route checking
+export * from "./utils/route-utils";

--- a/src/features/home/components/WelcomeMessage.tsx
+++ b/src/features/home/components/WelcomeMessage.tsx
@@ -1,4 +1,6 @@
 import { Button } from "@/shared/components/ui/button";
+import Link from "next/link";
+import { paths } from "@/config/routes";
 
 const WelcomeMessage = ({
   name,
@@ -12,8 +14,15 @@ const WelcomeMessage = ({
       <h1 className="text-5xl font-extrabold tracking-tight sm:text-[5rem]">
         Welcome <span className="text-[hsl(280,100%,70%)]">{name}</span>!
       </h1>
-      <div className="flex flex-col items-center gap-2">
-        <Button onClick={signOut}>{"Sign out"}</Button>
+      <div className="flex flex-col items-center gap-4">
+        <div className="flex gap-4">
+          <Link href={paths.sseDemoPage}>
+            <Button variant="secondary">SSE Demo</Button>
+          </Link>
+        </div>
+        <Button onClick={signOut} variant="destructive">
+          Sign out
+        </Button>
       </div>
     </>
   );

--- a/src/features/sse/components/SSEDemo.tsx
+++ b/src/features/sse/components/SSEDemo.tsx
@@ -1,0 +1,466 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/shared/components/ui/button";
+import {
+  useSSE,
+  useSSENotifications,
+  SSEConnectionState,
+} from "../hooks/useSSE";
+import { api } from "@/trpc/react";
+
+/**
+ * Connection status indicator component
+ */
+function ConnectionStatus({ state }: { state: SSEConnectionState }) {
+  const getStatusColor = () => {
+    switch (state) {
+      case SSEConnectionState.CONNECTED:
+        return "bg-green-500";
+      case SSEConnectionState.CONNECTING:
+      case SSEConnectionState.RECONNECTING:
+        return "bg-yellow-500";
+      case SSEConnectionState.ERROR:
+        return "bg-red-500";
+      default:
+        return "bg-gray-500";
+    }
+  };
+
+  const getStatusText = () => {
+    switch (state) {
+      case SSEConnectionState.CONNECTED:
+        return "Connected";
+      case SSEConnectionState.CONNECTING:
+        return "Connecting...";
+      case SSEConnectionState.RECONNECTING:
+        return "Reconnecting...";
+      case SSEConnectionState.ERROR:
+        return "Error";
+      default:
+        return "Disconnected";
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className={`h-3 w-3 rounded-full ${getStatusColor()}`} />
+      <span className="text-sm font-medium">{getStatusText()}</span>
+    </div>
+  );
+}
+
+/**
+ * Notification display component
+ */
+function NotificationList({
+  notifications,
+  onClear,
+}: {
+  notifications: Array<{
+    title: string;
+    message: string;
+    severity: "info" | "warning" | "error" | "success";
+    timestamp: number;
+  }>;
+  onClear: () => void;
+}) {
+  if (notifications.length === 0) {
+    return (
+      <div className="text-sm text-gray-500 italic">
+        No notifications yet. Try sending some!
+      </div>
+    );
+  }
+
+  const getSeverityStyles = (severity: string) => {
+    switch (severity) {
+      case "success":
+        return "border-green-500 bg-green-50 text-green-800";
+      case "error":
+        return "border-red-500 bg-red-50 text-red-800";
+      case "warning":
+        return "border-yellow-500 bg-yellow-50 text-yellow-800";
+      default:
+        return "border-blue-500 bg-blue-50 text-blue-800";
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h4 className="font-medium">Recent Notifications</h4>
+        <Button variant="destructive" size="sm" onClick={onClear}>
+          Clear All
+        </Button>
+      </div>
+      <div className="max-h-48 space-y-2 overflow-y-auto">
+        {notifications.map((notification) => (
+          <div
+            key={notification.timestamp}
+            className={`rounded-r border-l-4 p-3 ${getSeverityStyles(notification.severity)}`}
+          >
+            <div className="text-sm font-semibold">{notification.title}</div>
+            <div className="text-xs opacity-90">{notification.message}</div>
+            <div className="mt-1 text-xs opacity-70">
+              {new Date(notification.timestamp).toLocaleTimeString()}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Statistics card component
+ */
+function StatCard({
+  title,
+  value,
+  color = "text-blue-400",
+}: {
+  title: string;
+  value: string | number;
+  color?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-white/20 bg-white/10 p-4 text-center backdrop-blur-sm">
+      <div className={`text-2xl font-bold ${color}`}>{value}</div>
+      <div className="mt-1 text-sm text-gray-300">{title}</div>
+    </div>
+  );
+}
+
+export default function SSEDemo() {
+  const sse = useSSE({ debug: true });
+  const { notifications, clearNotifications } = useSSENotifications();
+  const [lastCustomEvent, setLastCustomEvent] = useState<any>(null);
+  const [uploadProgress, setUploadProgress] = useState<any>(null);
+
+  // mutations
+  const sendNotificationMutation = api.sse.sendDemoNotification.useMutation();
+  const pingMutation = api.sse.ping.useMutation();
+  const simulateUploadMutation = api.sse.simulateUploadProgress.useMutation();
+  const broadcastAlertMutation = api.sse.broadcastAlert.useMutation();
+  const statsQuery = api.sse.getStats.useQuery(undefined, {
+    refetchInterval: 60000, // 60 seconds
+  });
+
+  // Listen for custom events
+  useEffect(() => {
+    const unsubscribe = sse.addEventListener("ping", (event) => {
+      setLastCustomEvent({
+        type: "ping",
+        data: event.data,
+        timestamp: Date.now(),
+      });
+    });
+
+    return unsubscribe;
+  }, [sse]);
+
+  // Listen for upload progress
+  useEffect(() => {
+    const unsubscribe = sse.addEventListener("upload_progress", (event) => {
+      setUploadProgress(event.data);
+    });
+
+    const unsubscribeComplete = sse.addEventListener("upload_complete", () => {
+      setTimeout(() => setUploadProgress(null), 3000);
+    });
+
+    return () => {
+      unsubscribe();
+      unsubscribeComplete();
+    };
+  }, [sse]);
+
+  const handleSendDemoNotification = async () => {
+    try {
+      await sendNotificationMutation.mutateAsync();
+    } catch (error) {
+      console.error("Failed to send demo notification:", error);
+    }
+  };
+
+  const handlePing = async () => {
+    try {
+      await pingMutation.mutateAsync();
+    } catch (error) {
+      console.error("Failed to send ping:", error);
+    }
+  };
+
+  const handleSimulateUpload = async () => {
+    try {
+      await simulateUploadMutation.mutateAsync({
+        duration: 8000, // 8 seconds
+      });
+    } catch (error) {
+      console.error("Failed to simulate upload:", error);
+    }
+  };
+
+  const handleBroadcastAlert = async () => {
+    try {
+      await broadcastAlertMutation.mutateAsync({
+        title: "System Alert",
+        message: "This is a test system-wide alert!",
+        severity: "warning",
+      });
+    } catch (error) {
+      console.error("Failed to broadcast alert:", error);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-6">
+      <div className="text-center">
+        <h1 className="mb-2 text-4xl font-extrabold text-white">
+          SSE <span className="text-[hsl(280,100%,70%)]">Real-time</span> Demo
+        </h1>
+        <p className="text-lg text-gray-300">
+          Test the Server-Sent Events implementation with live notifications and
+          updates
+        </p>
+      </div>
+
+      {/* Connection Status */}
+      <div className="rounded-lg border border-white/20 bg-white/10 p-6 backdrop-blur-sm">
+        <h2 className="mb-4 text-xl font-semibold text-white">
+          Connection Status
+        </h2>
+        <div className="space-y-3">
+          <ConnectionStatus state={sse.connectionState} />
+          {sse.error && (
+            <div className="rounded border border-red-500/20 bg-red-900/20 p-2 text-sm text-red-400">
+              Error: {sse.error}
+            </div>
+          )}
+          <div className="text-sm text-gray-300">
+            Events received:{" "}
+            <span className="font-mono text-green-400">
+              {sse.stats.eventsReceived}
+            </span>
+          </div>
+          {sse.stats.connectionTime && (
+            <div className="text-sm text-gray-300">
+              Connected since:{" "}
+              <span className="font-mono text-blue-400">
+                {sse.stats.connectionTime.toLocaleTimeString()}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="mt-4 flex gap-3">
+          <Button
+            onClick={sse.connect}
+            disabled={sse.connectionState === SSEConnectionState.CONNECTED}
+            className="bg-green-600 text-white hover:bg-green-700"
+          >
+            Connect
+          </Button>
+          <Button
+            onClick={sse.disconnect}
+            disabled={sse.connectionState === SSEConnectionState.DISCONNECTED}
+            className="border-white/20 text-white hover:bg-white/10"
+          >
+            Disconnect
+          </Button>
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="rounded-lg border border-white/20 bg-white/10 p-6 backdrop-blur-sm">
+        <h2 className="mb-4 text-xl font-semibold text-white">Test Actions</h2>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
+          <Button
+            onClick={handleSendDemoNotification}
+            disabled={sendNotificationMutation.isPending}
+            className="bg-blue-600 text-white hover:bg-blue-700"
+          >
+            {sendNotificationMutation.isPending
+              ? "Sending..."
+              : "Demo Notification"}
+          </Button>
+
+          <Button
+            onClick={handlePing}
+            disabled={pingMutation.isPending}
+            className="border-white/20 text-white hover:bg-white/10"
+          >
+            {pingMutation.isPending ? "Pinging..." : "Ping Test"}
+          </Button>
+
+          <Button
+            onClick={handleSimulateUpload}
+            disabled={simulateUploadMutation.isPending}
+            className="bg-purple-600 text-white hover:bg-purple-700"
+          >
+            {simulateUploadMutation.isPending
+              ? "Starting..."
+              : "Simulate Upload"}
+          </Button>
+
+          <Button
+            onClick={handleBroadcastAlert}
+            disabled={broadcastAlertMutation.isPending}
+            className="bg-orange-600 text-white hover:bg-orange-700"
+          >
+            {broadcastAlertMutation.isPending
+              ? "Sending..."
+              : "Broadcast Alert"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Upload Progress */}
+      {uploadProgress && (
+        <div className="rounded-lg border border-white/20 bg-white/10 p-6 backdrop-blur-sm">
+          <h2 className="mb-4 text-xl font-semibold text-white">
+            Upload Progress
+          </h2>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-white">
+                Status:{" "}
+                <span className="text-purple-400">{uploadProgress.status}</span>
+              </span>
+              <span className="font-mono text-sm text-green-400">
+                {uploadProgress.progress}%
+              </span>
+            </div>
+            <div className="h-3 w-full overflow-hidden rounded-full bg-gray-700/50">
+              <div
+                className="h-3 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 transition-all duration-300 ease-out"
+                style={{ width: `${uploadProgress.progress}%` }}
+              />
+            </div>
+            <div className="text-sm text-gray-300">
+              {uploadProgress.message}
+            </div>
+            <div className="font-mono text-xs text-gray-400">
+              Upload ID: {uploadProgress.uploadId}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Statistics */}
+      <div className="rounded-lg border border-white/20 bg-white/10 p-6 backdrop-blur-sm">
+        <h2 className="mb-4 text-xl font-semibold text-white">
+          Connection Statistics
+        </h2>
+        {statsQuery.data ? (
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            <StatCard
+              title="Total Connections"
+              value={statsQuery.data.totalConnections}
+              color="text-blue-400"
+            />
+            <StatCard
+              title="Unique Users"
+              value={statsQuery.data.uniqueUsers}
+              color="text-green-400"
+            />
+            <StatCard
+              title="Your Connections"
+              value={statsQuery.data.currentUserConnections}
+              color="text-purple-400"
+            />
+            <StatCard
+              title="Events Received"
+              value={sse.stats.eventsReceived}
+              color="text-orange-400"
+            />
+          </div>
+        ) : (
+          <div className="p-8 text-center text-gray-300">
+            <div className="mx-auto mb-2 h-6 w-6 animate-spin rounded-full border-2 border-white/20 border-t-white"></div>
+            Loading stats...
+          </div>
+        )}
+      </div>
+
+      {/* Notifications */}
+      <div className="rounded-lg border border-white/20 bg-white/10 p-6 backdrop-blur-sm">
+        <h2 className="mb-4 text-xl font-semibold text-white">
+          Real-time Notifications
+        </h2>
+        <NotificationList
+          notifications={notifications}
+          onClear={clearNotifications}
+        />
+      </div>
+
+      {/* Custom Events */}
+      {lastCustomEvent && (
+        <div className="rounded-lg border border-white/20 bg-white/10 p-6 backdrop-blur-sm">
+          <h2 className="mb-4 text-xl font-semibold text-white">
+            Last Custom Event
+          </h2>
+          <div className="rounded-lg border border-white/10 bg-black/20 p-4 backdrop-blur-sm">
+            <div className="text-sm font-medium text-white">
+              Type:{" "}
+              <span className="font-mono text-cyan-400">
+                {lastCustomEvent.type}
+              </span>
+            </div>
+            <div className="mt-1 text-xs text-gray-400">
+              Received:{" "}
+              <span className="font-mono">
+                {new Date(
+                  lastCustomEvent.timestamp as unknown as string,
+                ).toLocaleTimeString()}
+              </span>
+            </div>
+            <div className="mt-3">
+              <div className="mb-1 text-xs text-gray-300">Event Data:</div>
+              <pre className="overflow-x-auto rounded border border-white/10 bg-black/30 p-2 font-mono text-xs text-green-300">
+                {JSON.stringify(lastCustomEvent.data, null, 2)}
+              </pre>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Debug Info */}
+      <div className="rounded-lg border border-white/10 bg-white/5 p-6 backdrop-blur-sm">
+        <h2 className="mb-4 text-xl font-semibold text-white">
+          Debug Information
+        </h2>
+        <div className="space-y-2 font-mono text-sm">
+          <div className="text-gray-300">
+            Connection State:{" "}
+            <span className="text-cyan-400">{sse.connectionState}</span>
+          </div>
+          <div className="text-gray-300">
+            Reconnect Attempts:{" "}
+            <span className="text-yellow-400">
+              {sse.stats.reconnectAttempts}
+            </span>
+          </div>
+          {sse.lastEvent && (
+            <div className="text-gray-300">
+              Last Event:{" "}
+              <span className="text-green-400">{sse.lastEvent.type}</span> at{" "}
+              <span className="text-blue-400">
+                {new Date().toLocaleTimeString()}
+              </span>
+            </div>
+          )}
+          {sse.error && (
+            <div className="rounded border border-red-500/20 bg-red-900/20 p-2 text-red-400">
+              Error: {sse.error}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/sse/hooks/useSSE.ts
+++ b/src/features/sse/hooks/useSSE.ts
@@ -1,0 +1,426 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useSession } from "../../../features/auth/client";
+import type {
+  SSEEvent,
+  NotificationEventData,
+  UploadProgressEventData,
+} from "../types";
+
+export enum SSEConnectionState {
+  DISCONNECTED = "disconnected",
+  CONNECTING = "connecting",
+  CONNECTED = "connected",
+  ERROR = "error",
+  RECONNECTING = "reconnecting",
+}
+
+export interface UseSSEOptions {
+  autoConnect?: boolean;
+  autoReconnect?: boolean;
+  reconnectDelay?: number;
+  maxReconnectAttempts?: number;
+  debug?: boolean;
+}
+
+export interface UseSSEReturn {
+  connectionState: SSEConnectionState;
+  lastEvent: SSEEvent | null;
+  error: string | null;
+  connect: () => void;
+  disconnect: () => void;
+  addEventListener: (
+    eventType: string,
+    handler: (event: SSEEvent) => void,
+  ) => () => void;
+  stats: {
+    connectionTime: Date | null;
+    reconnectAttempts: number;
+    eventsReceived: number;
+  };
+}
+
+function parseSSEEventData(data: unknown): unknown {
+  if (typeof data === "string") {
+    try {
+      return JSON.parse(data);
+    } catch {
+      return data;
+    }
+  }
+  return data;
+}
+
+function extractEventData(event: MessageEvent<unknown>): string {
+  if (typeof event.data === "string") {
+    return event.data;
+  }
+  // Fallback to string conversion for non-string data
+  return String(event.data);
+}
+
+export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
+  const {
+    autoConnect = true,
+    autoReconnect = true,
+    reconnectDelay = 3000,
+    maxReconnectAttempts = 5,
+    debug = false,
+  } = options;
+
+  const session = useSession();
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const eventListenersRef = useRef<Map<string, Set<(event: SSEEvent) => void>>>(
+    new Map(),
+  );
+
+  const [connectionState, setConnectionState] = useState<SSEConnectionState>(
+    SSEConnectionState.DISCONNECTED,
+  );
+  const [lastEvent, setLastEvent] = useState<SSEEvent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState({
+    connectionTime: null as Date | null,
+    reconnectAttempts: 0,
+    eventsReceived: 0,
+  });
+
+  const log = useCallback(
+    (message: string, ...args: unknown[]) => {
+      if (debug) {
+        console.log(`[useSSE] ${message}`, ...args);
+      }
+    },
+    [debug],
+  );
+
+  const addEventListener = useCallback(
+    (eventType: string, handler: (event: SSEEvent) => void): (() => void) => {
+      const listeners = eventListenersRef.current;
+
+      if (!listeners.has(eventType)) {
+        listeners.set(eventType, new Set());
+      }
+
+      listeners.get(eventType)!.add(handler);
+      log(`Added listener for event type: ${eventType}`);
+
+      return () => {
+        const typeListeners = listeners.get(eventType);
+        if (typeListeners) {
+          typeListeners.delete(handler);
+          if (typeListeners.size === 0) {
+            listeners.delete(eventType);
+          }
+        }
+        log(`Removed listener for event type: ${eventType}`);
+      };
+    },
+    [log],
+  );
+
+  const handleEvent = useCallback(
+    (event: SSEEvent) => {
+      log("Received event:", event);
+
+      setLastEvent(event);
+      setStats((prev) => ({
+        ...prev,
+        eventsReceived: prev.eventsReceived + 1,
+      }));
+
+      // Notify specific event listeners
+      const listeners = eventListenersRef.current.get(event.type);
+      if (listeners) {
+        listeners.forEach((handler) => {
+          try {
+            handler(event);
+          } catch (error) {
+            console.error(
+              `[useSSE] Error in event handler for ${event.type}:`,
+              error,
+            );
+          }
+        });
+      }
+
+      // Notify wildcard listeners
+      const wildcardListeners = eventListenersRef.current.get("*");
+      if (wildcardListeners) {
+        wildcardListeners.forEach((handler) => {
+          try {
+            handler(event);
+          } catch (error) {
+            console.error(`[useSSE] Error in wildcard event handler:`, error);
+          }
+        });
+      }
+    },
+    [log],
+  );
+
+  const connect = useCallback(() => {
+    if (!session) {
+      log("Cannot connect: No session");
+      setError("Authentication required");
+      return;
+    }
+
+    if (eventSourceRef.current) {
+      log("Already connected or connecting");
+      return;
+    }
+
+    log("Connecting to SSE...");
+    setConnectionState(SSEConnectionState.CONNECTING);
+    setError(null);
+
+    try {
+      const eventSource = new EventSource("/api/sse", {
+        withCredentials: true,
+      });
+
+      eventSourceRef.current = eventSource;
+
+      // Connection opened
+      eventSource.onopen = () => {
+        log("SSE connection opened");
+        setConnectionState(SSEConnectionState.CONNECTED);
+        setStats((prev) => ({
+          ...prev,
+          connectionTime: new Date(),
+          reconnectAttempts: 0,
+        }));
+      };
+
+      // Handle messages
+      eventSource.onmessage = (event) => {
+        try {
+          const eventData = extractEventData(event);
+          const data = parseSSEEventData(eventData);
+          handleEvent({
+            type: event.type || "message",
+            data,
+            id: event.lastEventId || undefined,
+          });
+        } catch (error) {
+          console.error("[useSSE] Error parsing message:", error);
+        }
+      };
+
+      const eventTypes = [
+        "heartbeat",
+        "user_notification",
+        "system_alert",
+        "upload_progress",
+        "upload_complete",
+        "connection_status",
+        "ping",
+        "custom",
+      ];
+
+      eventTypes.forEach((eventType) => {
+        eventSource.addEventListener(eventType, (event) => {
+          try {
+            const messageEvent = event as MessageEvent<unknown>;
+            const eventData = extractEventData(messageEvent);
+            const data = parseSSEEventData(eventData);
+            handleEvent({
+              type: eventType,
+              data,
+              id: messageEvent.lastEventId || undefined,
+            });
+          } catch (error) {
+            console.error(`[useSSE] Error parsing ${eventType} event:`, error);
+          }
+        });
+      });
+
+      // Handle errors
+      eventSource.onerror = (event) => {
+        log("SSE connection error:", event);
+
+        if (eventSource.readyState === EventSource.CLOSED) {
+          setConnectionState(SSEConnectionState.DISCONNECTED);
+          setError("Connection closed by server");
+
+          // Auto-reconnect if enabled
+          if (autoReconnect && stats.reconnectAttempts < maxReconnectAttempts) {
+            setConnectionState(SSEConnectionState.RECONNECTING);
+            setStats((prev) => ({
+              ...prev,
+              reconnectAttempts: prev.reconnectAttempts + 1,
+            }));
+
+            reconnectTimeoutRef.current = setTimeout(() => {
+              log(`Reconnecting... (attempt ${stats.reconnectAttempts + 1})`);
+              eventSourceRef.current = null;
+              connect();
+            }, reconnectDelay);
+          }
+        } else {
+          setConnectionState(SSEConnectionState.ERROR);
+          setError("Connection error occurred");
+        }
+      };
+    } catch (error) {
+      console.error("[useSSE] Failed to create EventSource:", error);
+      setConnectionState(SSEConnectionState.ERROR);
+      setError(error instanceof Error ? error.message : "Failed to connect");
+    }
+  }, [
+    session,
+    autoReconnect,
+    maxReconnectAttempts,
+    reconnectDelay,
+    stats.reconnectAttempts,
+    handleEvent,
+    log,
+  ]);
+
+  const disconnect = useCallback(() => {
+    log("Disconnecting from SSE...");
+
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+
+    setConnectionState(SSEConnectionState.DISCONNECTED);
+    setError(null);
+    setStats((prev) => ({
+      ...prev,
+      connectionTime: null,
+    }));
+  }, [log]);
+
+  // Auto-connect on mount if session is available
+  useEffect(() => {
+    if (
+      autoConnect &&
+      session &&
+      connectionState === SSEConnectionState.DISCONNECTED
+    ) {
+      connect();
+    }
+
+    return () => {
+      disconnect();
+    };
+  }, [session, autoConnect]);
+
+  useEffect(() => {
+    return () => {
+      disconnect();
+    };
+  }, [disconnect]);
+
+  return {
+    connectionState,
+    lastEvent,
+    error,
+    connect,
+    disconnect,
+    addEventListener,
+    stats,
+  };
+}
+
+function isNotificationEventData(data: unknown): data is NotificationEventData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "title" in data &&
+    "message" in data &&
+    "severity" in data &&
+    "timestamp" in data
+  );
+}
+
+function isUploadProgressEventData(
+  data: unknown,
+): data is UploadProgressEventData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "uploadId" in data &&
+    "progress" in data &&
+    "status" in data
+  );
+}
+
+export function useSSENotifications() {
+  const [notifications, setNotifications] = useState<NotificationEventData[]>(
+    [],
+  );
+  const sse = useSSE();
+
+  useEffect(() => {
+    const unsubscribe = sse.addEventListener("user_notification", (event) => {
+      if (isNotificationEventData(event.data)) {
+        const notification = event.data;
+        setNotifications((prev) => [notification, ...prev.slice(0, 9)]); // Keep last 10
+      } else {
+        console.warn(
+          "[useSSENotifications] Received invalid notification data:",
+          event.data,
+        );
+      }
+    });
+
+    return unsubscribe;
+  }, [sse]);
+
+  const clearNotifications = useCallback(() => {
+    setNotifications([]);
+  }, []);
+
+  const removeNotification = useCallback((timestamp: number) => {
+    setNotifications((prev) => prev.filter((n) => n.timestamp !== timestamp));
+  }, []);
+
+  return {
+    notifications,
+    clearNotifications,
+    removeNotification,
+    connectionState: sse.connectionState,
+  };
+}
+
+export function useSSEUploadProgress(uploadId?: string) {
+  const [progress, setProgress] = useState<UploadProgressEventData | null>(
+    null,
+  );
+  const sse = useSSE();
+
+  useEffect(() => {
+    const unsubscribe = sse.addEventListener("upload_progress", (event) => {
+      if (isUploadProgressEventData(event.data)) {
+        const progressData = event.data;
+
+        if (!uploadId || progressData.uploadId === uploadId) {
+          setProgress(progressData);
+        }
+      } else {
+        console.warn(
+          "[useSSEUploadProgress] Received invalid progress data:",
+          event.data,
+        );
+      }
+    });
+
+    return unsubscribe;
+  }, [sse, uploadId]);
+
+  return {
+    progress,
+    connectionState: sse.connectionState,
+  };
+}

--- a/src/features/sse/index.ts
+++ b/src/features/sse/index.ts
@@ -1,0 +1,20 @@
+// Services
+export { sseService } from "./services/sse-service";
+export { sseManager } from "./services/sse-manager";
+
+// Hooks
+export {
+  useSSE,
+  useSSENotifications,
+  useSSEUploadProgress,
+  SSEConnectionState,
+} from "./hooks/useSSE";
+
+// Components
+export { default as SSEDemo } from "./components/SSEDemo";
+
+// Types
+export * from "./types";
+
+// Router
+export { sseRouter } from "./trpc/router";

--- a/src/features/sse/package.json
+++ b/src/features/sse/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@features/sse",
+  "private": true,
+  "main": "./index.ts",
+  "types": "./index.ts"
+}

--- a/src/features/sse/services/sse-manager.ts
+++ b/src/features/sse/services/sse-manager.ts
@@ -1,0 +1,372 @@
+import { createServiceContext } from "@/utils/service-utils";
+import type {
+  SSEManager,
+  SSEConnection,
+  SSEEvent,
+  SSEManagerConfig,
+  HeartbeatEventData,
+} from "../types";
+
+const { log, handleError } = createServiceContext("SSEManager");
+
+const DEFAULT_CONFIG: SSEManagerConfig = {
+  heartbeatInterval: 60000,
+  connectionTimeout: 60000,
+  maxConnectionsPerUser: 5,
+  enableCleanup: true,
+  cleanupInterval: 60000,
+};
+
+export class SSEConnectionManager implements SSEManager {
+  private connections = new Map<
+    string,
+    {
+      connection: SSEConnection;
+      writer: WritableStreamDefaultWriter<Uint8Array>;
+    }
+  >();
+
+  private userConnections = new Map<string, Set<string>>();
+  private heartbeatInterval?: NodeJS.Timeout;
+  private cleanupInterval?: NodeJS.Timeout;
+  private config: SSEManagerConfig;
+
+  constructor(config: Partial<SSEManagerConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+
+    if (this.config.enableCleanup) {
+      this.startCleanupInterval();
+    }
+
+    this.startHeartbeatInterval();
+
+    log.info("SSE Manager initialized", {
+      heartbeatInterval: this.config.heartbeatInterval,
+      connectionTimeout: this.config.connectionTimeout,
+      maxConnectionsPerUser: this.config.maxConnectionsPerUser,
+    });
+  }
+
+  // Add new connection
+  addConnection(
+    userId: string,
+    writer: WritableStreamDefaultWriter<Uint8Array>,
+    metadata: Partial<SSEConnection> = {},
+  ): string {
+    try {
+      // Check connection limits
+      const existingConnections = this.getUserConnections(userId);
+      if (existingConnections.length >= this.config.maxConnectionsPerUser) {
+        // Remove oldest connection
+        const oldestConnection = existingConnections.sort(
+          (a, b) => a.connectedAt.getTime() - b.connectedAt.getTime(),
+        )[0];
+
+        if (oldestConnection) {
+          log.info("Removing oldest connection due to limit", {
+            userId,
+            oldConnectionId: oldestConnection.connectionId,
+            limit: this.config.maxConnectionsPerUser,
+          });
+          this.removeConnection(oldestConnection.connectionId);
+        }
+      }
+
+      const connectionId = `${userId}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      const now = new Date();
+
+      const connection: SSEConnection = {
+        userId,
+        connectionId,
+        connectedAt: now,
+        lastHeartbeat: now,
+        userAgent: metadata.userAgent,
+        clientIp: metadata.clientIp,
+      };
+
+      this.connections.set(connectionId, { connection, writer });
+
+      // Track user connections
+      if (!this.userConnections.has(userId)) {
+        this.userConnections.set(userId, new Set());
+      }
+      this.userConnections.get(userId)!.add(connectionId);
+
+      log.info("SSE connection added", {
+        userId,
+        connectionId,
+        totalConnections: this.connections.size,
+        userConnections: this.userConnections.get(userId)?.size ?? 0,
+      });
+
+      // Send initial connection status
+      void this.sendToConnection(connectionId, {
+        type: "connection_status",
+        data: {
+          status: "connected",
+          connectionId,
+          timestamp: Date.now(),
+        },
+      }).catch((error) => {
+        log.error("Failed to send connection status", error);
+      });
+
+      return connectionId;
+    } catch (error) {
+      return handleError("adding SSE connection", error);
+    }
+  }
+
+  // Remove an SSE connection
+  removeConnection(connectionId: string): boolean {
+    try {
+      const connectionData = this.connections.get(connectionId);
+      if (!connectionData) {
+        return false;
+      }
+
+      const { connection, writer } = connectionData;
+
+      try {
+        void writer.close().catch((error: unknown) => {
+          log.warn("Error closing SSE writer", { connectionId, error });
+        });
+      } catch (error) {
+        log.warn("Error closing SSE writer", { connectionId, error });
+      }
+
+      this.connections.delete(connectionId);
+
+      const userConnectionSet = this.userConnections.get(connection.userId);
+      if (userConnectionSet) {
+        userConnectionSet.delete(connectionId);
+        if (userConnectionSet.size === 0) {
+          this.userConnections.delete(connection.userId);
+        }
+      }
+
+      log.info("SSE connection removed", {
+        userId: connection.userId,
+        connectionId,
+        totalConnections: this.connections.size,
+      });
+
+      return true;
+    } catch (error) {
+      log.error("Error removing SSE connection", error, { connectionId });
+      return false;
+    }
+  }
+
+  // Get all connections for a user
+  getUserConnections(userId: string): SSEConnection[] {
+    const connectionIds = this.userConnections.get(userId) ?? new Set();
+    return Array.from(connectionIds)
+      .map((id) => this.connections.get(id)?.connection)
+      .filter((conn): conn is SSEConnection => conn !== undefined);
+  }
+
+  // Get all active connections
+  getAllConnections(): SSEConnection[] {
+    return Array.from(this.connections.values()).map(
+      ({ connection }) => connection,
+    );
+  }
+
+  // Send event to a specific connection
+  async sendToConnection(
+    connectionId: string,
+    event: SSEEvent,
+  ): Promise<boolean> {
+    try {
+      const connectionData = this.connections.get(connectionId);
+      if (!connectionData) {
+        log.warn("Connection not found", { connectionId });
+        return false;
+      }
+
+      const { writer, connection } = connectionData;
+      const sseData = this.formatSSEMessage(event);
+
+      await writer.write(new TextEncoder().encode(sseData));
+
+      // Update last heartbeat if this is a heartbeat event
+      if (event.type === "heartbeat") {
+        connection.lastHeartbeat = new Date();
+      }
+
+      return true;
+    } catch (error) {
+      log.error("Failed to send SSE message", error, {
+        connectionId,
+        eventType: event.type,
+      });
+
+      // Remove failed connection
+      this.removeConnection(connectionId);
+      return false;
+    }
+  }
+
+  // Send event to all connections of a user
+  async sendToUser(userId: string, event: SSEEvent): Promise<number> {
+    const connectionIds = this.userConnections.get(userId) ?? new Set();
+    let successCount = 0;
+
+    const promises = Array.from(connectionIds).map(async (connectionId) => {
+      const success = await this.sendToConnection(connectionId, event);
+      if (success) successCount++;
+    });
+
+    await Promise.all(promises);
+
+    log.info("Sent event to user connections", {
+      userId,
+      eventType: event.type,
+      totalConnections: connectionIds.size,
+      successfulSends: successCount,
+    });
+
+    return successCount;
+  }
+
+  // Broadcast event to all connections
+  async broadcast(event: SSEEvent): Promise<number> {
+    const allConnectionIds = Array.from(this.connections.keys());
+    let successCount = 0;
+
+    const promises = allConnectionIds.map(async (connectionId) => {
+      const success = await this.sendToConnection(connectionId, event);
+      if (success) successCount++;
+    });
+
+    await Promise.all(promises);
+
+    log.info("Broadcasted event to all connections", {
+      eventType: event.type,
+      totalConnections: allConnectionIds.length,
+      successfulSends: successCount,
+    });
+
+    return successCount;
+  }
+
+  // Maintain connections by sending periodic heartbeats
+  async sendHeartbeat(connectionId?: string): Promise<void> {
+    const heartbeatEvent: SSEEvent = {
+      type: "heartbeat",
+      data: {
+        timestamp: Date.now(),
+        connectionId: connectionId ?? "broadcast",
+      } as HeartbeatEventData,
+    };
+
+    if (connectionId) {
+      await this.sendToConnection(connectionId, heartbeatEvent);
+    } else {
+      await this.broadcast(heartbeatEvent);
+    }
+  }
+
+  // Clean up inactive connections
+  cleanup(): number {
+    const now = Date.now();
+    const timeoutMs = this.config.connectionTimeout;
+    let cleanedCount = 0;
+
+    const connectionsToRemove: string[] = [];
+
+    for (const [connectionId, { connection }] of this.connections) {
+      const timeSinceLastHeartbeat = now - connection.lastHeartbeat.getTime();
+
+      if (timeSinceLastHeartbeat > timeoutMs) {
+        connectionsToRemove.push(connectionId);
+      }
+    }
+
+    for (const connectionId of connectionsToRemove) {
+      if (this.removeConnection(connectionId)) {
+        cleanedCount++;
+      }
+    }
+
+    if (cleanedCount > 0) {
+      log.info("Cleaned up inactive connections", {
+        cleanedCount,
+        remainingConnections: this.connections.size,
+      });
+    }
+
+    return cleanedCount;
+  }
+
+  // Start periodic heartbeat
+  private startHeartbeatInterval(): void {
+    this.heartbeatInterval = setInterval(() => {
+      void this.sendHeartbeat().catch((error) => {
+        log.error("Error sending heartbeat", error);
+      });
+    }, this.config.heartbeatInterval);
+  }
+
+  // Start periodic cleanup
+  private startCleanupInterval(): void {
+    this.cleanupInterval = setInterval(() => {
+      try {
+        this.cleanup();
+      } catch (error) {
+        log.error("Error during cleanup", error);
+      }
+    }, this.config.cleanupInterval);
+  }
+
+  // Format SSE message
+  private formatSSEMessage(event: SSEEvent): string {
+    let message = "";
+
+    if (event.id) {
+      message += `id: ${event.id}\n`;
+    }
+
+    if (event.type) {
+      message += `event: ${event.type}\n`;
+    }
+
+    if (event.retry) {
+      message += `retry: ${event.retry}\n`;
+    }
+
+    const data =
+      typeof event.data === "string" ? event.data : JSON.stringify(event.data);
+
+    // Split multi-line data
+    const dataLines = data.split("\n");
+    for (const line of dataLines) {
+      message += `data: ${line}\n`;
+    }
+
+    message += "\n";
+
+    return message;
+  }
+
+  // Cleanup resources
+  destroy(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+    }
+
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+    }
+
+    for (const connectionId of this.connections.keys()) {
+      this.removeConnection(connectionId);
+    }
+
+    log.info("SSE Manager destroyed");
+  }
+}
+
+// singleton instance
+export const sseManager = new SSEConnectionManager();

--- a/src/features/sse/services/sse-service.ts
+++ b/src/features/sse/services/sse-service.ts
@@ -1,0 +1,224 @@
+import { createServiceContext } from "@/utils/service-utils";
+import { sseManager } from "./sse-manager";
+import type {
+  SSEService,
+  NotificationEventData,
+  UploadProgressEventData,
+} from "../types";
+
+const { log, handleError } = createServiceContext("SSEService");
+
+class SSEBusinessService implements SSEService {
+  // Send a notification to a specific user
+  async notifyUser(
+    userId: string,
+    notification: NotificationEventData,
+  ): Promise<boolean> {
+    try {
+      log.info("Sending notification to user", {
+        userId,
+        title: notification.title,
+        severity: notification.severity,
+      });
+
+      const event = {
+        type: "user_notification",
+        data: {
+          ...notification,
+          timestamp: Date.now(),
+        },
+        id: `notification-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      };
+
+      const successCount = await sseManager.sendToUser(userId, event);
+
+      log.info("Notification sent", {
+        userId,
+        successCount,
+        notificationId: event.id,
+      });
+
+      return successCount > 0;
+    } catch (error) {
+      return handleError("sending user notification", error);
+    }
+  }
+
+  // Broadcast a system alert to all connected users
+  async broadcastAlert(alert: NotificationEventData): Promise<number> {
+    try {
+      log.info("Broadcasting system alert", {
+        title: alert.title,
+        severity: alert.severity,
+      });
+
+      const event = {
+        type: "system_alert",
+        data: {
+          ...alert,
+          timestamp: Date.now(),
+        },
+        id: `alert-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      };
+
+      const successCount = await sseManager.broadcast(event);
+
+      log.info("System alert broadcasted", {
+        successCount,
+        alertId: event.id,
+      });
+
+      return successCount;
+    } catch (error) {
+      return handleError("broadcasting system alert", error);
+    }
+  }
+
+  // Update upload progress for a user
+  async updateUploadProgress(
+    userId: string,
+    progress: UploadProgressEventData,
+  ): Promise<boolean> {
+    try {
+      const event = {
+        type: "upload_progress",
+        data: progress,
+        id: `upload-${progress.uploadId}-${Date.now()}`,
+      };
+
+      const successCount = await sseManager.sendToUser(userId, event);
+
+      if (progress.status === "complete") {
+        log.info("Upload completed", {
+          userId,
+          uploadId: progress.uploadId,
+          successCount,
+        });
+      }
+
+      return successCount > 0;
+    } catch (error) {
+      log.error("Failed to update upload progress", error, {
+        userId,
+        uploadId: progress.uploadId,
+      });
+      return false;
+    }
+  }
+
+  // Send a custom event
+  async sendCustomEvent<T = Record<string, unknown>>(
+    userId: string | null,
+    eventType: string,
+    data: T,
+  ): Promise<number> {
+    try {
+      const event = {
+        type: eventType,
+        data,
+        id: `custom-${eventType}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      };
+
+      let successCount: number;
+
+      if (userId) {
+        successCount = await sseManager.sendToUser(userId, event);
+        log.info("Custom event sent to user", {
+          userId,
+          eventType,
+          successCount,
+        });
+      } else {
+        successCount = await sseManager.broadcast(event);
+        log.info("Custom event broadcasted", {
+          eventType,
+          successCount,
+        });
+      }
+
+      return successCount;
+    } catch (error) {
+      log.error("Failed to send custom event", error, {
+        userId,
+        eventType,
+      });
+      return 0;
+    }
+  }
+
+  // Get connection stats
+  getStats() {
+    try {
+      const allConnections = sseManager.getAllConnections();
+      const userCounts: Record<string, number> = {};
+
+      for (const connection of allConnections) {
+        userCounts[connection.userId] =
+          (userCounts[connection.userId] ?? 0) + 1;
+      }
+
+      const stats = {
+        totalConnections: allConnections.length,
+        uniqueUsers: Object.keys(userCounts).length,
+        connectionsPerUser: userCounts,
+      };
+
+      log.info("Generated SSE stats", stats);
+      return stats;
+    } catch (error) {
+      log.error("Failed to generate SSE stats", error);
+      return {
+        totalConnections: 0,
+        uniqueUsers: 0,
+        connectionsPerUser: {},
+      };
+    }
+  }
+
+  // Send a welcome message to a newly connected user
+  async sendWelcomeMessage(
+    userId: string,
+    userName?: string,
+  ): Promise<boolean> {
+    const welcomeNotification: NotificationEventData = {
+      title: "Connected!",
+      message: `Welcome ${userName ?? "User"}! You're now receiving real-time updates.`,
+      severity: "success",
+      timestamp: Date.now(),
+    };
+
+    return this.notifyUser(userId, welcomeNotification);
+  }
+
+  // // TODO: Adding if needed
+  // // Typing indicator
+  // async sendTypingIndicator(
+  //   userId: string,
+  //   isTyping: boolean,
+  // ): Promise<boolean> {
+  //   return (
+  //     (await this.sendCustomEvent(userId, "typing_indicator", {
+  //       isTyping,
+  //       timestamp: Date.now(),
+  //     })) > 0
+  //   );
+  // }
+
+  // Send system notifications
+  async notifyMaintenance(
+    message: string,
+    scheduledTime?: Date,
+  ): Promise<number> {
+    const maintenanceAlert: NotificationEventData = {
+      title: "System Maintenance",
+      message,
+      severity: "warning",
+      timestamp: Date.now(),
+    };
+
+    return this.broadcastAlert(maintenanceAlert);
+  }
+}
+
+// singleton instance
+export const sseService = new SSEBusinessService();

--- a/src/features/sse/trpc/router.ts
+++ b/src/features/sse/trpc/router.ts
@@ -1,0 +1,261 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "@/lib/trpc";
+import { sseService } from "../services/sse-service";
+import { sseManager } from "../services/sse-manager";
+import { TRPCError } from "@trpc/server";
+
+const NotificationInputSchema = z.object({
+  title: z.string().min(1).max(100),
+  message: z.string().min(1).max(500),
+  severity: z.enum(["info", "warning", "error", "success"]).default("info"),
+});
+
+const CustomEventInputSchema = z.object({
+  eventType: z.string().min(1).max(50),
+  data: z.record(z.unknown()),
+  targetUserId: z.string().optional(),
+});
+
+const BroadcastAlertInputSchema = z.object({
+  title: z.string().min(1).max(100),
+  message: z.string().min(1).max(500),
+  severity: z.enum(["info", "warning", "error", "success"]).default("warning"),
+});
+
+export const sseRouter = createTRPCRouter({
+  sendNotification: protectedProcedure
+    .input(NotificationInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const success = await sseService.notifyUser(ctx.session.user.id, {
+          title: input.title,
+          message: input.message,
+          severity: input.severity,
+          timestamp: Date.now(),
+        });
+
+        if (!success) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to send notification",
+          });
+        }
+
+        return { success: true, message: "Notification sent successfully" };
+      } catch (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to send notification",
+        });
+      }
+    }),
+
+  sendCustomEvent: protectedProcedure
+    .input(CustomEventInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const targetUserId = input.targetUserId ?? ctx.session.user.id;
+        const successCount = await sseService.sendCustomEvent(
+          targetUserId,
+          input.eventType,
+          input.data,
+        );
+
+        return {
+          success: successCount > 0,
+          message: `Event sent to ${successCount} connection(s)`,
+          successCount,
+        };
+      } catch (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to send custom event",
+        });
+      }
+    }),
+
+  broadcastAlert: protectedProcedure
+    .input(BroadcastAlertInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const successCount = await sseService.broadcastAlert({
+          title: input.title,
+          message: input.message,
+          severity: input.severity,
+          timestamp: Date.now(),
+        });
+
+        return {
+          success: successCount > 0,
+          message: `Alert broadcasted to ${successCount} connection(s)`,
+          successCount,
+        };
+      } catch (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to broadcast alert",
+        });
+      }
+    }),
+
+  getStats: protectedProcedure.query(async ({ ctx }) => {
+    try {
+      const stats = sseService.getStats();
+      const userConnections = sseManager.getUserConnections(
+        ctx.session.user.id,
+      );
+
+      return {
+        ...stats,
+        currentUserConnections: userConnections.length,
+        currentUserConnectionDetails: userConnections,
+      };
+    } catch (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to get SSE stats",
+      });
+    }
+  }),
+
+  ping: protectedProcedure.mutation(async ({ ctx }) => {
+    try {
+      const success = await sseService.sendCustomEvent(
+        ctx.session.user.id,
+        "ping",
+        {
+          message: "Pong! SSE is working correctly.",
+          timestamp: Date.now(),
+          userId: ctx.session.user.id,
+        },
+      );
+
+      return {
+        success: success > 0,
+        message:
+          success > 0
+            ? "Ping sent successfully"
+            : "No active connections found",
+        connectionsReached: success,
+      };
+    } catch (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to send ping",
+      });
+    }
+  }),
+
+  sendDemoNotification: protectedProcedure.mutation(async ({ ctx }) => {
+    try {
+      const demoMessages = [
+        {
+          title: "Demo Success",
+          message: "This is a success notification!",
+          severity: "success" as const,
+        },
+        {
+          title: "Demo Info",
+          message: "This is an info notification with some details.",
+          severity: "info" as const,
+        },
+        {
+          title: "Demo Warning",
+          message: "This is a warning notification. Please pay attention!",
+          severity: "warning" as const,
+        },
+        {
+          title: "Demo Error",
+          message: "This is an error notification. Something went wrong!",
+          severity: "error" as const,
+        },
+      ];
+
+      const randomDemo =
+        demoMessages[Math.floor(Math.random() * demoMessages.length)]!;
+
+      const success = await sseService.notifyUser(ctx.session.user.id, {
+        ...randomDemo,
+        timestamp: Date.now(),
+      });
+
+      return {
+        success,
+        message: success
+          ? "Demo notification sent!"
+          : "Failed to send demo notification",
+        demoType: randomDemo.severity,
+      };
+    } catch (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to send demo notification",
+      });
+    }
+  }),
+
+  simulateUploadProgress: protectedProcedure
+    .input(
+      z.object({
+        duration: z.number().min(1000).max(30000).default(5000), // 1-30 seconds
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const uploadId = `demo-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        const userId = ctx.session.user.id;
+        const steps = 10;
+        const interval = input.duration / steps;
+
+        for (let i = 0; i <= steps; i++) {
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
+          setTimeout(async () => {
+            const progress = Math.round((i / steps) * 100);
+            let status: "uploading" | "processing" | "complete" | "error";
+            let message: string;
+
+            if (i === 0) {
+              status = "uploading";
+              message = "Starting upload...";
+            } else if (i < steps * 0.7) {
+              status = "uploading";
+              message = `Uploading... ${progress}%`;
+            } else if (i < steps) {
+              status = "processing";
+              message = "Processing video...";
+            } else {
+              status = "complete";
+              message = "Upload complete!";
+            }
+
+            await sseService.updateUploadProgress(userId, {
+              uploadId,
+              progress,
+              status,
+              message,
+            });
+
+            if (i === steps) {
+              await sseService.sendCustomEvent(userId, "upload_complete", {
+                uploadId,
+                assetId: `asset-${uploadId}`,
+                message: "Your video is ready for viewing!",
+              });
+            }
+          }, i * interval);
+        }
+
+        return {
+          success: true,
+          message: "Upload simulation started",
+          uploadId,
+          duration: input.duration,
+        };
+      } catch (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to simulate upload progress",
+        });
+      }
+    }),
+});

--- a/src/features/sse/types/index.ts
+++ b/src/features/sse/types/index.ts
@@ -1,0 +1,107 @@
+export interface SSEEvent {
+  type: string;
+  data: unknown;
+  id?: string;
+  retry?: number;
+}
+
+export interface SSEConnection {
+  userId: string;
+  connectionId: string;
+  connectedAt: Date;
+  lastHeartbeat: Date;
+  userAgent?: string;
+  clientIp?: string;
+}
+
+export interface SSEManager {
+  addConnection(
+    userId: string,
+    writer: WritableStreamDefaultWriter<Uint8Array>,
+    metadata?: Partial<SSEConnection>,
+  ): string;
+  removeConnection(connectionId: string): boolean;
+  getUserConnections(userId: string): SSEConnection[];
+  getAllConnections(): SSEConnection[];
+  sendToConnection(connectionId: string, event: SSEEvent): Promise<boolean>;
+  sendToUser(userId: string, event: SSEEvent): Promise<number>;
+  broadcast(event: SSEEvent): Promise<number>;
+  sendHeartbeat(connectionId?: string): Promise<void>;
+  cleanup(): number;
+}
+
+export interface SSEManagerConfig {
+  heartbeatInterval: number;
+  connectionTimeout: number;
+  maxConnectionsPerUser: number;
+  enableCleanup: boolean;
+  cleanupInterval: number;
+}
+
+export enum SSEEventType {
+  HEARTBEAT = "heartbeat",
+  USER_NOTIFICATION = "user_notification",
+  SYSTEM_ALERT = "system_alert",
+  UPLOAD_PROGRESS = "upload_progress",
+  UPLOAD_COMPLETE = "upload_complete",
+  CONNECTION_STATUS = "connection_status",
+  CUSTOM = "custom",
+}
+
+export interface HeartbeatEventData {
+  timestamp: number;
+  connectionId: string;
+}
+
+export interface NotificationEventData {
+  title: string;
+  message: string;
+  severity: "info" | "warning" | "error" | "success";
+  timestamp: number;
+}
+
+export interface UploadProgressEventData {
+  uploadId: string;
+  progress: number; // 0-100
+  status: "uploading" | "processing" | "complete" | "error";
+  message?: string;
+}
+
+export interface ConnectionStatusEventData {
+  status: "connected" | "disconnected" | "error";
+  connectionId: string;
+  timestamp: number;
+  reason?: string;
+}
+
+export type EventDataMap = {
+  [SSEEventType.HEARTBEAT]: HeartbeatEventData;
+  [SSEEventType.USER_NOTIFICATION]: NotificationEventData;
+  [SSEEventType.SYSTEM_ALERT]: NotificationEventData;
+  [SSEEventType.UPLOAD_PROGRESS]: UploadProgressEventData;
+  [SSEEventType.UPLOAD_COMPLETE]: { uploadId: string; assetId?: string };
+  [SSEEventType.CONNECTION_STATUS]: ConnectionStatusEventData;
+  [SSEEventType.CUSTOM]: Record<string, unknown>;
+};
+
+export interface SSEService {
+  notifyUser(
+    userId: string,
+    notification: NotificationEventData,
+  ): Promise<boolean>;
+  broadcastAlert(alert: NotificationEventData): Promise<number>;
+  updateUploadProgress(
+    userId: string,
+    progress: UploadProgressEventData,
+  ): Promise<boolean>;
+  sendCustomEvent<T = Record<string, unknown>>(
+    userId: string | null,
+    eventType: string,
+    data: T,
+  ): Promise<number>;
+  getStats(): {
+    totalConnections: number;
+    uniqueUsers: number;
+    connectionsPerUser: Record<string, number>;
+  };
+}

--- a/src/lib/trpc/root.ts
+++ b/src/lib/trpc/root.ts
@@ -1,5 +1,6 @@
 import { createCallerFactory, createTRPCRouter } from "@/lib/trpc";
 import { searchRouter } from "@/features/search";
+import { sseRouter } from "@/features/sse";
 
 /**
  * This is the primary router for your server.
@@ -8,6 +9,7 @@ import { searchRouter } from "@/features/search";
  */
 export const appRouter = createTRPCRouter({
   search: searchRouter,
+  sse: sseRouter,
 });
 
 // export type definition of API


### PR DESCRIPTION
Adding New SSE Manager changes :
- SSE Connection Manager: Handles connection lifecycle, user tracking, and automatic cleanup
- SSE API Service: High-level API for common use cases (notifications, alerts, progress updates)
- /api/sse: Main streaming endpoint for establishing SSE connections
- /api/sse/stats: Connection statistics and monitoring
- /api/admin/sse/broadcast: Admin endpoint for system-wide alerts
- tRPC Integration: new endpoints( heartbeat, user_notification, system_alert, upload_progress, upload_complete, connection_status, and custom) for triggering SSE events programmatically
- React Integration:
- - useSSE(): Main hook for SSE connections with auto-reconnection
- - useSSENotifications(): Specialized hook for notification management
- Client-Side Utils: Standalone SSE client for non-React contexts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Server-Sent Events (SSE) with protected streaming endpoint, user-targeted notifications, system alerts, custom events, and connection statistics.
  * Added an interactive SSE Demo page showing live connection status, recent notifications, ping results, upload progress simulation, and periodic stats.
  * Added an “SSE Demo” button on the home screen to navigate to the new page.
* **Chores / Configuration**
  * Updated ignore rules for local tooling and temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->