### PR TITLE
feat: implement reusable SSE manager and demo UI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Nomey Web App
+
 This is the official repository for the Nomey web app, built on the T3 Stack with custom extensions.
 
 ## Tech Stack
@@ -12,7 +13,7 @@ This is the official repository for the Nomey web app, built on the T3 Stack wit
 - [tolgee](https://tolgee.io/) - Translation Management
 - [Meilisearch](https://www.meilisearch.com/) - Full-text search
 - [Upstash](https://upstash.com/) Next compatible redis
-- [Qstash](https://upstash.com/docs/qstash) Next compatible queue handling 
+- [Qstash](https://upstash.com/docs/qstash) Next compatible queue handling
 - [Vitest](https://vitest.dev/) - Testing Framework
 
 ## Testing
@@ -42,6 +43,7 @@ npm run test
 ## Local Development
 
 ### Clone and Install
+
 ```bash
 git clone git@github.com:nomeyy/nomey-next.git
 cd nomey-next
@@ -62,7 +64,7 @@ npm run dev
 
 ## Learn More
 
- - [Nomey Documentation (WIP)](https://nomey.mintlify.app/)
- - [Next Documentation](https://nextjs.org/docs)
- - [T3 Stack Documentation](https://create.t3.gg/en/usage/first-steps)
- - [Mux Documentation](https://www.mux.com/docs)
+- [Nomey Documentation (WIP)](https://nomey.mintlify.app/)
+- [Next Documentation](https://nextjs.org/docs)
+- [T3 Stack Documentation](https://create.t3.gg/en/usage/first-steps)
+- [Mux Documentation](https://www.mux.com/docs)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2106,7 +2106,7 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
       "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jiti": "2.4.2"
@@ -2116,14 +2116,14 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
       "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
       "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2137,14 +2137,14 @@
       "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
       "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
       "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.10.1",
@@ -2156,7 +2156,7 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
       "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.10.1"
@@ -3429,7 +3429,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5026,7 +5026,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-media-element": {
@@ -7334,7 +7334,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -9053,7 +9053,7 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
       "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10552,6 +10552,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/app/(protected)/home/SSEClient.tsx
+++ b/src/app/(protected)/home/SSEClient.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type SSEClientProps = {
+  userId: string;
+};
+
+export function SSEClient({ userId }: SSEClientProps) {
+  const [message, setMessage] = useState<string>("(No messages yet)");
+
+  useEffect(() => {
+    const evtSource = new EventSource(`/api/sse?id=${userId}`);
+
+    const onNotification = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data);
+        setMessage(JSON.stringify(data));
+      } catch {
+        setMessage(e.data);
+      }
+    };
+
+    evtSource.addEventListener("notification", onNotification);
+
+    // Optional: handle other events, e.g., ping
+    evtSource.addEventListener("ping", () => {
+      console.log("ping");
+    });
+
+    return () => {
+      evtSource.removeEventListener("notification", onNotification);
+      evtSource.close();
+    };
+  }, [userId]);
+
+  return (
+    <div style={{ marginTop: 16 }}>
+      <div>
+        <strong>Latest SSE message:</strong>
+      </div>
+      <div
+        style={{
+          padding: 8,
+          border: "1px solid #ccc",
+          borderRadius: 4,
+          marginBottom: 8,
+          minHeight: 24,
+        }}
+        data-testid="sse-message"
+      >
+        {message}
+      </div>
+      <button onClick={() => setMessage("(No messages yet)")}>Clear</button>
+    </div>
+  );
+}

--- a/src/app/(protected)/home/page.tsx
+++ b/src/app/(protected)/home/page.tsx
@@ -1,5 +1,6 @@
 import { getSession, signOut } from "@/features/auth";
 import { WelcomeMessage } from "@/features/home";
+import { SSEClient } from "./SSEClient";
 
 const HomePage = async () => {
   const session = await getSession();
@@ -10,7 +11,10 @@ const HomePage = async () => {
   };
 
   return (
-    <WelcomeMessage name={session?.user.name ?? ""} signOut={handleSignOut} />
+    <>
+      <WelcomeMessage name={session?.user.name ?? ""} signOut={handleSignOut} />
+      {session?.user?.id && <SSEClient userId={session.user.id} />}
+    </>
   );
 };
 

--- a/src/app/api/sse/route.ts
+++ b/src/app/api/sse/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { sseManager } from "@/features/sse";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clientId = searchParams.get("id") || crypto.randomUUID();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      const res = {
+        write: (chunk: string) => controller.enqueue(encoder.encode(chunk)),
+        on: () => {}, // no-op for ReadableStream
+      };
+      sseManager.addClient(clientId, res as any);
+      // Initial handshake
+      res.write(`event: connected\ndata: {}\n\n`);
+    },
+    cancel() {
+      sseManager.removeClient(clientId);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/api/test-sse-broadcast/route.ts
+++ b/src/app/api/test-sse-broadcast/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sseManager } from "@/features/sse";
+
+export async function POST(req: NextRequest) {
+  const { message } = await req.json();
+
+  sseManager.broadcastEvent({
+    event: "notification",
+    data: { message },
+  });
+
+  return NextResponse.json({ status: "broadcast sent" });
+}

--- a/src/app/api/test-sse/route.ts
+++ b/src/app/api/test-sse/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sseManager } from "@/features/sse";
+
+export async function POST(req: NextRequest) {
+  const { userId, message } = await req.json();
+
+  sseManager.sendEventToClient(userId, {
+    event: "notification",
+    data: { message },
+  });
+
+  return NextResponse.json({ status: "sent" });
+}

--- a/src/features/sse/index.ts
+++ b/src/features/sse/index.ts
@@ -1,0 +1,2 @@
+export * from "./sse-manager";
+export * from "./types";

--- a/src/features/sse/sse-manager.ts
+++ b/src/features/sse/sse-manager.ts
@@ -1,0 +1,52 @@
+import type { SSEClient, SSEEvent } from "./types";
+
+class SSEManager {
+  private clients: Map<string, SSEClient> = new Map();
+  private heartbeatInterval: NodeJS.Timeout | null = null;
+
+  constructor() {
+    this.startHeartbeat();
+  }
+
+  addClient(id: string, res: NodeJS.WritableStream) {
+    this.clients.set(id, { id, res });
+    res.on("close", () => this.removeClient(id));
+    res.on("error", () => this.removeClient(id));
+  }
+
+  removeClient(id: string) {
+    this.clients.delete(id);
+  }
+
+  sendEventToClient(id: string, event: SSEEvent) {
+    const client = this.clients.get(id);
+    if (client) {
+      this.writeEvent(client.res, event);
+    }
+  }
+
+  broadcastEvent(event: SSEEvent) {
+    for (const client of this.clients.values()) {
+      this.writeEvent(client.res, event);
+    }
+  }
+
+  private writeEvent(res: NodeJS.WritableStream, event: SSEEvent) {
+    res.write(`event: ${event.event}\n`);
+    res.write(`data: ${JSON.stringify(event.data)}\n\n`);
+  }
+
+  private startHeartbeat() {
+    this.heartbeatInterval = setInterval(() => {
+      for (const client of this.clients.values()) {
+        client.res.write(`event: ping\ndata: {}\n\n`);
+      }
+    }, 25000); // 25s, less than most proxies' 30s timeout
+  }
+
+  stopHeartbeat() {
+    if (this.heartbeatInterval) clearInterval(this.heartbeatInterval);
+  }
+}
+
+export const sseManager = new SSEManager();

--- a/src/features/sse/types.ts
+++ b/src/features/sse/types.ts
@@ -1,0 +1,9 @@
+export type SSEClient = {
+  id: string; // userId, sessionId, or random
+  res: NodeJS.WritableStream;
+};
+
+export type SSEEvent = {
+  event: string;
+  data: any;
+};


### PR DESCRIPTION
## Summary

- Implemented a reusable, abstracted Server-Sent Events (SSE) layer for real-time notifications.
- Added `/api/sse` endpoint for client connections.
- Added `/api/test-sse` and `/api/test-sse-broadcast` endpoints for testing individual and broadcast notifications.
- Minimal UI proof: a component that displays the latest SSE message and a clear button.

## How to Test

1. Open the protected home page as a logged-in user.
2. POST to `/api/test-sse` with your userId to send a notification to yourself. 
```
curl -X POST http://localhost:3000/api/test-sse \
  -H "Content-Type: application/json" \
  -d '{"userId": "<your_user_id>", "message": "Hello from backend!"}'
```
3. POST to `/api/test-sse-broadcast` to send a notification to all connected clients. 
```
curl -X POST http://localhost:3000/api/test-sse-broadcast \
  -H "Content-Type: application/json" \
  -d '{"message":"Hello to all clients!"}'
```
4. The UI updates in real time.

## Demo

Loom video link here: https://www.loom.com/share/72c6c076959a4c2780fd7406709b7d48?sid=191ee720-a85e-4b39-b0da-027be56e3129

## Notes

- Heartbeat/ping and disconnect cleanup are handled automatically.
- See `src/features/sse/` for the core implementation.