### PR TITLE
feat: Add Server-Sent Events (SSE) feature

### DIFF
--- a/src/app/(protected)/home/page.tsx
+++ b/src/app/(protected)/home/page.tsx
@@ -1,16 +1,20 @@
 import { getSession, signOut } from "@/features/auth";
 import { WelcomeMessage } from "@/features/home";
+import { SseMessenger } from "@/features/sse";
 
 const HomePage = async () => {
   const session = await getSession();
-
+  
   const handleSignOut = async () => {
     "use server";
     await signOut();
   };
 
   return (
-    <WelcomeMessage name={session?.user.name ?? ""} signOut={handleSignOut} />
+    <>
+      <WelcomeMessage name={session?.user.name ?? ""} signOut={handleSignOut} />
+      <SseMessenger />
+    </>
   );
 };
 

--- a/src/app/api/sse/route.ts
+++ b/src/app/api/sse/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/features/sse";
+
+export const { GET } = handlers;

--- a/src/app/api/webhooks/sse/route.ts
+++ b/src/app/api/webhooks/sse/route.ts
@@ -1,0 +1,3 @@
+import { webhooksHandlers } from "@/features/sse";
+
+export const { POST } = webhooksHandlers;

--- a/src/features/sse/__tests__/sse.service.test.ts
+++ b/src/features/sse/__tests__/sse.service.test.ts
@@ -1,0 +1,122 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { type SseClientResponse } from "../types";
+import type { sseService as SseServiceType } from "../services/sse.service";
+
+let sseService: typeof SseServiceType;
+
+class MockResponse implements SseClientResponse {
+  data = "";
+  ended = false;
+  writableEnded = false;
+
+  write(chunk: string) {
+    this.data += chunk;
+  }
+
+  end() {
+    this.ended = true;
+    this.writableEnded = true;
+  }
+}
+
+vi.mock("@/utils/logging", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("SseService", () => {
+  let mockRes: MockResponse;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    const { sseService: service } = await import("../services/sse.service");
+    sseService = service;
+
+    mockRes = new MockResponse();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should add a client", () => {
+    sseService.addClient("user1", { res: mockRes });
+    expect(sseService.getClients().has("user1")).toBe(true);
+    expect(sseService.getClients().get("user1")?.res).toBe(mockRes);
+  });
+
+  it("should remove a client", () => {
+    sseService.addClient("user1", { res: mockRes });
+    sseService.removeClient("user1");
+    expect(sseService.getClients().has("user1")).toBe(false);
+    expect(mockRes.ended).toBe(true);
+  });
+
+  it("should send a message to a specific user (default event)", () => {
+    sseService.addClient("user1", { res: mockRes });
+    const data = { message: "Hello" };
+    sseService.sendToUser("user1", data);
+    expect(mockRes.data).toBe(`data: ${JSON.stringify(data)}\n\n`);
+  });
+
+  it("should send a named event to a specific user", () => {
+    sseService.addClient("user1", { res: mockRes });
+    const data = { message: "Named Hello" };
+    sseService.sendToUser("user1", data, "greeting");
+    // The data should include the event field
+    expect(mockRes.data).toBe(
+      `event: greeting\ndata: ${JSON.stringify(data)}\n\n`,
+    );
+  });
+
+  it("should broadcast a message to all clients (default event)", () => {
+    const mockRes2 = new MockResponse();
+    sseService.addClient("user1", { res: mockRes });
+    sseService.addClient("user2", { res: mockRes2 });
+
+    const data = { message: "Broadcast" };
+    sseService.broadcast(data);
+
+    expect(mockRes.data).toBe(`data: ${JSON.stringify(data)}\n\n`);
+    expect(mockRes2.data).toBe(`data: ${JSON.stringify(data)}\n\n`);
+  });
+
+  it("should broadcast a named event to all clients", () => {
+    const mockRes2 = new MockResponse();
+    sseService.addClient("user1", { res: mockRes });
+    sseService.addClient("user2", { res: mockRes2 });
+
+    const data = { message: "Named Broadcast" };
+    sseService.broadcast(data, "announcement");
+
+    expect(mockRes.data).toBe(
+      `event: announcement\ndata: ${JSON.stringify(data)}\n\n`,
+    );
+    expect(mockRes2.data).toBe(
+      `event: announcement\ndata: ${JSON.stringify(data)}\n\n`,
+    );
+  });
+
+  it("should send heartbeat messages", () => {
+    sseService.addClient("user1", { res: mockRes });
+    vi.advanceTimersByTime(10000);
+    expect(mockRes.data).toBe(`:heartbeat\n\n`);
+  });
+
+  it("should remove disconnected clients during heartbeat", () => {
+    mockRes.writableEnded = true;
+    sseService.addClient("user1", { res: mockRes });
+
+    expect(sseService.getClients().has("user1")).toBe(true);
+
+    vi.advanceTimersByTime(10000);
+
+    expect(sseService.getClients().has("user1")).toBe(false);
+  });
+});

--- a/src/features/sse/components/SseMessenger.tsx
+++ b/src/features/sse/components/SseMessenger.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const SseMessenger = () => {
+  const [message, setMessage] = useState<string>("");
+  const [messages, setMessages] = useState<string[]>([]);
+
+  const handleSendMessage = async () => {
+    // Use a "greeting" event name when broadcasting
+    fetch("/api/webhooks/sse", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        event: "greeting",
+        data: message,
+      }),
+    })
+      .then(() => {
+        setMessage("");
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  useEffect(() => {
+    const evtSource = new EventSource("/api/sse");
+    // Listen for the "greeting" named event
+    evtSource.addEventListener("greeting", (event: MessageEvent) => {
+      setMessages((prev) => [...prev, event.data as string]);
+    });
+
+    return () => {
+      evtSource.close();
+    };
+  }, []);
+
+  return (
+    <div>
+      <div>
+        {messages.map((m, idx) => (
+          <div key={idx}>{m}</div>
+        ))}
+      </div>
+      <input
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        placeholder="Type your message"
+      />
+      <button onClick={handleSendMessage}>Send</button>
+    </div>
+  );
+};

--- a/src/features/sse/handlers/index.ts
+++ b/src/features/sse/handlers/index.ts
@@ -1,0 +1,62 @@
+import { sseService, type SseClient } from "@/features/sse";
+import { logger } from "@/utils/logging";
+import type { NextRequest } from "next/server";
+import { getSession } from "@/features/auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const session = await getSession();
+  if (!session) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const userId = session.user.id;
+
+  // Sets up streaming response, following the OpenAI reference pattern
+  const responseStream = new TransformStream();
+  const writer = responseStream.writable.getWriter();
+  const encoder = new TextEncoder();
+
+  // Set up SSE client to use the writer API, if needed
+  const client: SseClient = {
+    res: {
+      writableEnded: false,
+      write: (data: string) => {
+        try {
+          void writer.write(encoder.encode(data));
+        } catch (e: unknown) {
+          logger.error("Error writing to SSE stream", String(e));
+        }
+      },
+      end: () => {
+        try {
+          void writer.close();
+        } catch {
+          // Ignore error
+        }
+      },
+    },
+  };
+
+  sseService.addClient(userId, client);
+  sseService.sendToUser(userId, "Hi");
+  // This will end/cleanup the stream if the HTTP connection is aborted
+  req.signal.addEventListener("abort", () => {
+    sseService.removeClient(userId);
+    try {
+      void writer.close();
+    } catch {
+      /* Ignore */
+    }
+  });
+
+  return new Response(responseStream.readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache, no-transform",
+    },
+  });
+}

--- a/src/features/sse/handlers/webhook.ts
+++ b/src/features/sse/handlers/webhook.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from "next/server";
+import { sseService } from "@/features/sse";
+import type { WebhookBodySSE } from "../types";
+import { logger } from "@/utils/logging";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const { event, data } = (await request.json()) as WebhookBodySSE;
+  logger.info("Event", event);
+  logger.info("Data", String(data));
+  // Broadcast to all SSE clients
+  sseService.broadcast(data, event);
+
+  return new Response("Broadcasted", { status: 200 });
+}

--- a/src/features/sse/index.ts
+++ b/src/features/sse/index.ts
@@ -1,0 +1,5 @@
+export * from "./services/sse.service";
+export * from "./types";
+export * from "./components/SseMessenger";
+export * as handlers from "./handlers";
+export * as webhooksHandlers from "./handlers/webhook";

--- a/src/features/sse/package.json
+++ b/src/features/sse/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@features/sse",
+  "private": true,
+  "main": "./index.ts",
+  "types": "./index.ts"
+}

--- a/src/features/sse/services/sse.service.ts
+++ b/src/features/sse/services/sse.service.ts
@@ -1,0 +1,198 @@
+import { EventEmitter } from "events";
+import { logger } from "@/utils/logging";
+import type { SseClient } from "../types";
+
+// Extend global namespace to store the singleton
+declare global {
+  var __sseService: SseService | undefined;
+}
+
+class SseService extends EventEmitter {
+  private clients = new Map<string, SseClient>();
+  private static readonly TAG = "SseService";
+  private heartbeatInterval: NodeJS.Timeout | null = null;
+
+  constructor() {
+    super();
+    logger.info(SseService.TAG, "SseService instance created/reused");
+    this.initHeartbeat();
+  }
+
+  private initHeartbeat() {
+    // Clear existing interval if any
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+    }
+
+    this.heartbeatInterval = setInterval(() => {
+      logger.debug(
+        SseService.TAG,
+        `Heartbeat check - clients count: ${this.clients.size}`,
+      );
+
+      this.clients.forEach((client, userId) => {
+        if (client.res.writableEnded) {
+          logger.info(
+            SseService.TAG,
+            `Client for user ${userId} disconnected, removing from pool`,
+          );
+          this.removeClient(userId);
+        } else {
+          try {
+            client.res.write(":heartbeat\n\n");
+          } catch (error) {
+            logger.error(
+              SseService.TAG,
+              `Error writing heartbeat to user ${userId}:`,
+              error,
+            );
+            this.removeClient(userId);
+          }
+        }
+      });
+    }, 10000);
+  }
+
+  addClient(userId: string, client: SseClient) {
+    this.clients.set(userId, client);
+    logger.info(
+      SseService.TAG,
+      `Client added for user ${userId}. Total clients: ${this.clients.size}`,
+    );
+    this.emit("clientAdded", userId);
+  }
+
+  removeClient(userId: string) {
+    const client = this.clients.get(userId);
+    if (client) {
+      try {
+        if (!client.res.writableEnded) {
+          client.res.end();
+        }
+      } catch (error) {
+        logger.warn(
+          SseService.TAG,
+          `Error ending response for user ${userId}:`,
+          error,
+        );
+      }
+      this.clients.delete(userId);
+      logger.info(
+        SseService.TAG,
+        `Client removed for user ${userId}. Remaining clients: ${this.clients.size}`,
+      );
+      this.emit("clientRemoved", userId);
+    }
+  }
+
+  sendToUser(userId: string, data: unknown, eventName?: string): boolean {
+    const client = this.clients.get(userId);
+    if (client) {
+      try {
+        let payload = "";
+        if (eventName) {
+          payload += `event: ${eventName}\n`;
+        }
+        payload += `data: ${JSON.stringify(data)}\n\n`;
+        client.res.write(payload);
+        logger.info(
+          SseService.TAG,
+          `Sent message to user ${userId}${eventName ? " (event: " + eventName + ")" : ""}`,
+        );
+        return true;
+      } catch (error) {
+        logger.error(
+          SseService.TAG,
+          `Error sending message to user ${userId}:`,
+          error,
+        );
+        this.removeClient(userId);
+        return false;
+      }
+    }
+    logger.warn(SseService.TAG, `No client found for user ${userId}`);
+    return false;
+  }
+
+  broadcast(data: unknown, eventName?: string) {
+    logger.info(
+      SseService.TAG,
+      `Broadcasting message to all clients${eventName ? " (event: " + eventName + ")" : ""}`,
+    );
+    logger.info(SseService.TAG, `Clients count: ${this.clients.size}`);
+
+    if (this.clients.size === 0) {
+      logger.warn(SseService.TAG, "No clients to broadcast to");
+      return;
+    }
+
+    // Create array to avoid concurrent modification issues
+    const clientEntries = Array.from(this.clients.entries());
+
+    clientEntries.forEach(([userId, _client]) => {
+      this.sendToUser(userId, data, eventName);
+    });
+  }
+
+  // Get current client count for debugging
+  getClientCount(): number {
+    return this.clients.size;
+  }
+
+  // Get all connected user IDs for debugging
+  getConnectedUsers(): string[] {
+    return Array.from(this.clients.keys());
+  }
+
+  getClients(): Map<string, SseClient> {
+    return this.clients;
+  }
+
+  // Cleanup method
+  cleanup() {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+
+    // Close all client connections
+    this.clients.forEach((client, userId) => {
+      try {
+        if (!client.res.writableEnded) {
+          client.res.end();
+        }
+      } catch (error) {
+        logger.warn(
+          SseService.TAG,
+          `Error closing connection for user ${userId}:`,
+          error,
+        );
+      }
+    });
+
+    this.clients.clear();
+    this.removeAllListeners();
+  }
+}
+
+function getSseService(): SseService {
+  if (!globalThis.__sseService) {
+    globalThis.__sseService = new SseService();
+
+    process.on("SIGINT", () => {
+      if (globalThis.__sseService) {
+        globalThis.__sseService.cleanup();
+      }
+    });
+
+    process.on("SIGTERM", () => {
+      if (globalThis.__sseService) {
+        globalThis.__sseService.cleanup();
+      }
+    });
+  }
+
+  return globalThis.__sseService;
+}
+
+export const sseService = getSseService();

--- a/src/features/sse/types.ts
+++ b/src/features/sse/types.ts
@@ -1,0 +1,13 @@
+export interface SseClient {
+  res: SseClientResponse;
+}
+export interface SseClientResponse {
+  write: (data: string) => void;
+  end: () => void;
+  writableEnded: boolean;
+}
+
+export interface WebhookBodySSE {
+  event: string;
+  data: unknown;
+}


### PR DESCRIPTION
  This PR introduces a new Server-Sent Events (SSE) feature to the application.

  The feature includes:
   - A dedicated sse module with a service for managing SSE clients and broadcasting events.
   - An API route (/api/sse) for clients to establish an SSE connection.
   - A webhook (/api/webhooks/sse) to receive and broadcast messages to connected clients.
   - A new SseMessenger component that connects to the SSE endpoint, receives messages, and allows sending messages through the webhook.
   - Integration of the SseMessenger component into the home page.

<img width="1859" height="954" alt="Screenshot 2025-08-06 133322" src="https://github.com/user-attachments/assets/90f9cd33-034f-47a4-b53c-7fc8d879cee8" />
<img width="1911" height="928" alt="Screenshot 2025-08-06 133537" src="https://github.com/user-attachments/assets/0942e7b0-390b-4a58-8f23-7ffd881c0711" />
<img width="1895" height="954" alt="Screenshot 2025-08-06 133551" src="https://github.com/user-attachments/assets/e0523a45-a3ac-449c-81a2-47911585e20e" />
<img width="1909" height="935" alt="Screenshot 2025-08-06 133605" src="https://github.com/user-attachments/assets/2ffa3ed7-acbc-4123-9214-66eb5a96e331" />
<img width="1397" height="577" alt="Screenshot 2025-08-06 133704" src="https://github.com/user-attachments/assets/a46fdd1d-c46d-4dff-a5d5-5abc0ed60b84" />
