### PR TITLE
feat: implement comprehensive Server-Sent Events (SSE) system

### DIFF
--- a/src/app/(public)/sse/layout.tsx
+++ b/src/app/(public)/sse/layout.tsx
@@ -1,0 +1,7 @@
+export default function SSELayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/(public)/sse/page.tsx
+++ b/src/app/(public)/sse/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSSEConnection } from "@/hooks/useSSEConnection";
+import {
+  ConnectionStatus,
+  EventLog,
+  MetricsPanel,
+  EventSender,
+  HealthMonitor,
+} from "@/features/sse";
+
+export default function SSEDashboard() {
+  const [userId, setUserId] = useState("");
+  const [sessionId, setSessionId] = useState("");
+  const [autoConnect, setAutoConnect] = useState(false);
+
+  const {
+    connected,
+    connecting,
+    error,
+    events,
+    metrics,
+    health,
+    connect,
+    disconnect,
+    sendEvent,
+    clearEvents,
+  } = useSSEConnection();
+
+  // Auto-generate session ID on mount
+  useEffect(() => {
+    setSessionId(`session-${Math.random().toString(36).substr(2, 9)}`);
+  }, []);
+
+  const handleConnect = useCallback(() => {
+    connect({
+      userId: userId || undefined,
+      sessionId: sessionId || undefined,
+    });
+  }, [connect, userId, sessionId]);
+
+  const handleDisconnect = useCallback(() => {
+    disconnect();
+  }, [disconnect]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <div className="mx-auto max-w-7xl">
+        {/* Header */}
+        <div className="mb-6 rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
+          <h1 className="mb-2 text-3xl font-bold text-gray-900 dark:text-white">
+            SSE Dashboard
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400">
+            Real-time Server-Sent Events monitoring and testing
+          </p>
+        </div>
+
+        {/* Connection Controls */}
+        <div className="mb-6 rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
+            Connection Settings
+          </h2>
+
+          <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                User ID (optional)
+              </label>
+              <input
+                type="text"
+                value={userId}
+                onChange={(e) => setUserId(e.target.value)}
+                placeholder="e.g., user-1"
+                className="relative z-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+                disabled={connected || connecting}
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Session ID
+              </label>
+              <input
+                type="text"
+                value={sessionId}
+                onChange={(e) => setSessionId(e.target.value)}
+                placeholder="e.g., session-abc"
+                className="relative z-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+                disabled={connected || connecting}
+              />
+            </div>
+
+            <div className="flex items-end">
+              {!connected ? (
+                <button
+                  onClick={handleConnect}
+                  disabled={connecting}
+                  className="w-full rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+                >
+                  {connecting ? "Connecting..." : "Connect"}
+                </button>
+              ) : (
+                <button
+                  onClick={handleDisconnect}
+                  className="w-full rounded-md bg-red-600 px-4 py-2 text-white transition-colors hover:bg-red-700"
+                >
+                  Disconnect
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              id="autoConnect"
+              checked={autoConnect}
+              onChange={(e) => setAutoConnect(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500"
+            />
+            <label
+              htmlFor="autoConnect"
+              className="text-sm text-gray-700 dark:text-gray-300"
+            >
+              Auto-reconnect on connection loss
+            </label>
+          </div>
+        </div>
+
+        {/* Status Bar */}
+        <ConnectionStatus
+          connected={connected}
+          connecting={connecting}
+          error={error}
+          health={health}
+        />
+
+        {/* Main Grid */}
+        <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+          {/* Metrics Panel */}
+          <MetricsPanel metrics={metrics} />
+
+          {/* Health Monitor */}
+          <HealthMonitor health={health} connected={connected} />
+        </div>
+
+        {/* Event Sender */}
+        <EventSender
+          connected={connected}
+          onSendEvent={sendEvent}
+          userId={userId}
+          sessionId={sessionId}
+        />
+
+        {/* Event Log */}
+        <EventLog events={events} onClear={clearEvents} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/sse/heartbeat/route.ts
+++ b/src/app/api/sse/heartbeat/route.ts
@@ -1,0 +1,98 @@
+/**
+ * SSE Heartbeat/Ping Endpoint
+ *
+ * POST /api/sse/heartbeat - Handle client ping
+ * GET /api/sse/heartbeat - Get heartbeat configuration
+ */
+
+import { type NextRequest } from "next/server";
+import { getSSEService, SSEErrorCode } from "@/lib/sse";
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  validateRequestBody,
+  PingRequestSchema,
+} from "../utils";
+
+// Get SSE service instance
+const sseService = getSSEService();
+
+/**
+ * Handle client ping
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Validate request body
+    const validation = await validateRequestBody(request, PingRequestSchema);
+
+    if (!validation.success) {
+      return createErrorResponse(validation.error, 400);
+    }
+
+    const { clientId } = validation.data;
+
+    // Handle the ping
+    const result = sseService.handlePing(clientId);
+
+    if (!result.success) {
+      return createErrorResponse(
+        result.error.message,
+        result.error.code === SSEErrorCode.CLIENT_NOT_FOUND ? 404 : 500,
+        result.error.details,
+      );
+    }
+
+    return createSuccessResponse({
+      clientId,
+      timestamp: Date.now(),
+      message: "Pong",
+    });
+  } catch (error) {
+    console.error("Failed to handle ping:", error);
+    return createErrorResponse(
+      "Failed to handle ping",
+      500,
+      error instanceof Error ? error.message : "Unknown error",
+    );
+  }
+}
+
+/**
+ * Get heartbeat configuration and stats
+ */
+export async function GET() {
+  try {
+    const status = sseService.getStatus();
+    const healthStats = status.metrics.health;
+
+    return createSuccessResponse({
+      config: status.config.health,
+      stats: {
+        totalHeartbeatsSent: healthStats.totalHeartbeatsSent,
+        totalHeartbeatsReceived: healthStats.totalHeartbeatsReceived,
+        clientTimeouts: healthStats.clientTimeouts,
+        lastHeartbeat: healthStats.lastHeartbeat,
+        unhealthyConnections: healthStats.unhealthyConnections,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to get heartbeat info:", error);
+    return createErrorResponse(
+      "Failed to retrieve heartbeat information",
+      500,
+      error instanceof Error ? error.message : "Unknown error",
+    );
+  }
+}
+
+// Handle OPTIONS for CORS
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}

--- a/src/app/api/sse/metrics/route.ts
+++ b/src/app/api/sse/metrics/route.ts
@@ -1,0 +1,74 @@
+/**
+ * SSE Metrics Endpoint
+ *
+ * GET /api/sse/metrics - Get current SSE service metrics
+ */
+
+import { getSSEService } from "@/lib/sse";
+import { createSuccessResponse, createErrorResponse } from "../utils";
+
+// Get SSE service instance
+const sseService = getSSEService();
+
+export async function GET() {
+  try {
+    // Get current metrics
+    const metrics = sseService.getMetrics();
+    const status = sseService.getStatus();
+    const health = sseService.getHealth();
+
+    // Transform metrics for frontend
+    const transformedMetrics = {
+      connections: {
+        active: metrics.connections.active,
+        total: metrics.connections.total,
+        byUser: metrics.connections.byUser.size,
+        bySession: metrics.connections.bySession.size,
+      },
+      events: {
+        sent: metrics.events.sent,
+        received: 0, // Not tracked in backend, placeholder for frontend
+        failed: metrics.events.failed,
+        rate: metrics.events.rate,
+      },
+      performance: {
+        memoryUsageMB: metrics.performance.memoryUsageMB,
+        uptime: metrics.performance.uptime,
+        averageLatency: metrics.performance.avgEventDeliveryMs, // Use correct property name
+      },
+    };
+
+    console.info("Metrics requested", {
+      activeConnections: metrics.connections.active,
+      health,
+    });
+
+    return createSuccessResponse({
+      metrics: transformedMetrics,
+      status: {
+        initialized: status.initialized,
+        shuttingDown: status.shuttingDown,
+        health,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to get metrics:", error);
+    return createErrorResponse(
+      "Failed to retrieve metrics",
+      500,
+      error instanceof Error ? error.message : "Unknown error",
+    );
+  }
+}
+
+// Handle OPTIONS for CORS
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}

--- a/src/app/api/sse/route.ts
+++ b/src/app/api/sse/route.ts
@@ -1,0 +1,88 @@
+/**
+ * SSE Connection Endpoint
+ * 
+ * GET /api/sse - Establish SSE connection
+ */
+
+import { type NextRequest } from 'next/server';
+import { getSSEService, SSEErrorCode } from '@/lib/sse';
+import {
+  createErrorResponse,
+  createSSEHeaders,
+  extractClientMetadata,
+  parseQueryParams,
+  ConnectionParamsSchema
+} from './utils';
+
+// Initialize SSE service
+const sseService = getSSEService();
+
+// Ensure service is initialized
+sseService.initialize().catch(console.error);
+
+export async function GET(request: NextRequest) {
+  try {
+    // Parse and validate query parameters
+    const params = parseQueryParams(request.url);
+    const validation = ConnectionParamsSchema.safeParse(params);
+    
+    if (!validation.success) {
+      return createErrorResponse(
+        'Invalid connection parameters',
+        400,
+        validation.error.errors
+      );
+    }
+    
+    // Extract client metadata
+    const metadata = extractClientMetadata(request);
+    
+    // Create SSE connection
+    const result = sseService.createConnection({
+      userId: validation.data.userId,
+      sessionId: validation.data.sessionId,
+      metadata
+    });
+    
+    if (!result.success) {
+      return createErrorResponse(
+        result.error.message,
+        result.error.code === SSEErrorCode.MAX_CONNECTIONS_REACHED ? 503 : 500,
+        result.error.details
+      );
+    }
+    
+    const { clientId, stream } = result.data;
+    
+    console.info('SSE connection established', {
+      clientId,
+      userId: validation.data.userId,
+      sessionId: validation.data.sessionId,
+      userAgent: metadata.userAgent
+    });
+    
+    // Return the stream with SSE headers
+    return new Response(stream, {
+      headers: createSSEHeaders()
+    });
+  } catch (error) {
+    console.error('Failed to establish SSE connection:', error);
+    return createErrorResponse(
+      'Failed to establish SSE connection',
+      500,
+      error instanceof Error ? error.message : 'Unknown error'
+    );
+  }
+}
+
+// Handle OPTIONS for CORS
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    }
+  });
+}

--- a/src/app/api/sse/send/route.ts
+++ b/src/app/api/sse/send/route.ts
@@ -1,0 +1,101 @@
+/**
+ * SSE Send Event Endpoint
+ *
+ * POST /api/sse/send - Send events to connected clients
+ */
+
+import { type NextRequest } from "next/server";
+import { getSSEService, SSEErrorCode } from "@/lib/sse";
+import type { EventTarget } from "@/lib/sse";
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  validateRequestBody,
+  SendEventRequestSchema,
+} from "../utils";
+
+// Get SSE service instance
+const sseService = getSSEService();
+
+export async function POST(request: NextRequest) {
+  try {
+    // Validate request body
+    const validation = await validateRequestBody(
+      request,
+      SendEventRequestSchema,
+    );
+
+    if (!validation.success) {
+      return createErrorResponse(validation.error, 400);
+    }
+
+    const { target, targetId, event } = validation.data;
+
+    // Additional validation for targetId requirement
+    if (target !== "broadcast" && target !== "all" && !targetId) {
+      return createErrorResponse(
+        `Target ID is required for target type: ${target}`,
+        400,
+      );
+    }
+
+    // Send the event
+    const result = sseService.send({
+      target: target as EventTarget,
+      targetId,
+      event: {
+        type: event.type,
+        data: event.data,
+        id: event.id,
+        retry: event.retry,
+      },
+    });
+
+    if (!result.success) {
+      return createErrorResponse(
+        result.error.message,
+        result.error.code === SSEErrorCode.CLIENT_NOT_FOUND ? 404 : 500,
+        result.error.details,
+      );
+    }
+
+    // Get current metrics for response
+    const metrics = sseService.getMetrics();
+
+    console.info("Event sent successfully", {
+      target,
+      targetId,
+      eventType: event.type,
+      sentCount: result.data.sentCount,
+      failedCount: result.data.failedCount,
+    });
+
+    return createSuccessResponse({
+      ...result.data,
+      stats: {
+        activeConnections: metrics.connections.active,
+        totalConnections: metrics.connections.total,
+        eventRate: metrics.events.rate,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to send event:", error);
+    return createErrorResponse(
+      "Failed to send event",
+      500,
+      error instanceof Error ? error.message : "Unknown error",
+    );
+  }
+}
+
+// Handle OPTIONS for CORS
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}

--- a/src/app/api/sse/stats/route.ts
+++ b/src/app/api/sse/stats/route.ts
@@ -1,0 +1,64 @@
+/**
+ * SSE Statistics Endpoint
+ * 
+ * GET /api/sse/stats - Get SSE system statistics
+ */
+
+import { type NextRequest } from 'next/server';
+import { getSSEService } from '@/lib/sse';
+import { createSuccessResponse, createErrorResponse } from '../utils';
+
+// Get SSE service instance
+const sseService = getSSEService();
+
+export async function GET(request: NextRequest) {
+  try {
+    // Get comprehensive metrics
+    const metrics = sseService.getMetrics();
+    const health = sseService.getHealth();
+    const status = sseService.getStatus();
+    
+    // Get detailed report if requested
+    const { searchParams } = new URL(request.url);
+    const detailed = searchParams.get('detailed') === 'true';
+    
+    if (detailed) {
+      const report = sseService.getDetailedReport();
+      return createSuccessResponse(report);
+    }
+    
+    // Return standard metrics
+    return createSuccessResponse({
+      health,
+      metrics,
+      status: {
+        initialized: status.initialized,
+        shuttingDown: status.shuttingDown
+      },
+      connections: {
+        current: sseService.getConnectionCount(),
+        max: status.config.maxConnections,
+        utilization: `${Math.round((sseService.getConnectionCount() / status.config.maxConnections) * 100)}%`
+      }
+    });
+  } catch (error) {
+    console.error('Failed to get stats:', error);
+    return createErrorResponse(
+      'Failed to retrieve statistics',
+      500,
+      error instanceof Error ? error.message : 'Unknown error'
+    );
+  }
+}
+
+// Handle OPTIONS for CORS
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    }
+  });
+}

--- a/src/app/api/sse/status/route.ts
+++ b/src/app/api/sse/status/route.ts
@@ -1,0 +1,41 @@
+/**
+ * SSE Status Endpoint
+ *
+ * GET /api/sse/status - Get detailed SSE service status
+ */
+
+import { getSSEService } from "@/lib/sse";
+import { createSuccessResponse, createErrorResponse } from "../utils";
+
+// Get SSE service instance
+const sseService = getSSEService();
+
+export async function GET() {
+  try {
+    // Get detailed report
+    const report = sseService.getDetailedReport();
+
+    console.info("Status report requested");
+
+    return createSuccessResponse(report);
+  } catch (error) {
+    console.error("Failed to get status:", error);
+    return createErrorResponse(
+      "Failed to retrieve status",
+      500,
+      error instanceof Error ? error.message : "Unknown error",
+    );
+  }
+}
+
+// Handle OPTIONS for CORS
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
+}

--- a/src/app/api/sse/utils.ts
+++ b/src/app/api/sse/utils.ts
@@ -1,0 +1,159 @@
+/**
+ * SSE API Utilities
+ *
+ * Shared utilities for SSE API endpoints
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+// Validation schemas
+export const ConnectionParamsSchema = z.object({
+  userId: z.string().min(1).max(100).optional(),
+  sessionId: z.string().min(1).max(100).optional(),
+});
+
+export const SendEventRequestSchema = z.object({
+  target: z.enum(["client", "user", "session", "broadcast", "all"]),
+  targetId: z.string().min(1).max(100).optional(),
+  event: z.object({
+    type: z.string().min(1).max(100),
+    data: z.unknown(), // Required field - can be any JSON-serializable value
+    id: z.string().optional(),
+    retry: z.number().positive().optional(),
+  }),
+});
+
+export const PingRequestSchema = z.object({
+  clientId: z.string().min(1),
+});
+
+interface ErrorResponse {
+  success: false;
+  error: string;
+  details?: unknown;
+}
+
+interface SuccessResponse {
+  success: true;
+  data: unknown;
+  message?: string;
+}
+
+/**
+ * Create error response
+ */
+export function createErrorResponse(
+  message: string,
+  status = 500,
+  details?: unknown,
+): Response {
+  console.error(`SSE API Error: ${message}`, details);
+
+  const errorResponse: ErrorResponse = {
+    success: false,
+    error: message,
+  };
+
+  if (details !== undefined) {
+    errorResponse.details = details;
+  }
+
+  return NextResponse.json(errorResponse, { status });
+}
+
+/**
+ * Create success response
+ */
+export function createSuccessResponse(
+  data: unknown,
+  message?: string,
+): Response {
+  const response: SuccessResponse = {
+    success: true,
+    data,
+  };
+
+  if (message) {
+    response.message = message;
+  }
+
+  return NextResponse.json(response);
+}
+
+/**
+ * Extract client metadata from request
+ */
+export function extractClientMetadata(request: Request): {
+  userAgent?: string;
+  ip?: string;
+  referer?: string;
+} {
+  const headers = request.headers;
+
+  return {
+    userAgent: headers.get("user-agent") ?? undefined,
+    ip: headers.get("x-forwarded-for") ?? headers.get("x-real-ip") ?? undefined,
+    referer: headers.get("referer") ?? undefined,
+  };
+}
+
+/**
+ * Validate request body
+ */
+export async function validateRequestBody<T>(
+  request: Request,
+  schema: z.ZodSchema<T>,
+): Promise<{ success: true; data: T } | { success: false; error: string }> {
+  try {
+    const body = (await request.json()) as T;
+    const result = schema.safeParse(body);
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: result.error.errors[0]?.message ?? "Validation failed",
+      };
+    }
+
+    return {
+      success: true,
+      data: result.data,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: "Invalid JSON body",
+    };
+  }
+}
+
+/**
+ * Parse query parameters
+ */
+export function parseQueryParams(url: string): {
+  userId?: string;
+  sessionId?: string;
+} {
+  const { searchParams } = new URL(url);
+
+  return {
+    userId: searchParams.get("userId") ?? undefined,
+    sessionId: searchParams.get("sessionId") ?? undefined,
+  };
+}
+
+/**
+ * Create SSE headers
+ */
+export function createSSEHeaders(): HeadersInit {
+  return {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}

--- a/src/features/sse/components/ConnectionStatus.tsx
+++ b/src/features/sse/components/ConnectionStatus.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import type { SSEHealth } from "@/hooks/useSSEConnection";
+
+interface ConnectionStatusProps {
+  connected: boolean;
+  connecting: boolean;
+  error: string | null;
+  health: SSEHealth;
+}
+
+export function ConnectionStatus({
+  connected,
+  connecting,
+  error,
+  health,
+}: ConnectionStatusProps) {
+  const getStatusColor = () => {
+    if (connecting) return "bg-yellow-100 border-yellow-300 text-yellow-800";
+    if (connected && health.status === "healthy") return "bg-green-100 border-green-300 text-green-800";
+    if (connected && health.status === "degraded") return "bg-orange-100 border-orange-300 text-orange-800";
+    if (error || health.status === "unhealthy") return "bg-red-100 border-red-300 text-red-800";
+    return "bg-gray-100 border-gray-300 text-gray-800";
+  };
+
+  const getStatusText = () => {
+    if (connecting) return "Connecting...";
+    if (connected && health.status === "healthy") return "Connected";
+    if (connected && health.status === "degraded") return "Connected (Degraded)";
+    if (error) return `Error: ${error}`;
+    if (health.status === "unhealthy") return "Disconnected (Unhealthy)";
+    return "Disconnected";
+  };
+
+  const getStatusIcon = () => {
+    if (connecting) {
+      return (
+        <svg className="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+      );
+    }
+    if (connected && health.status === "healthy") {
+      return (
+        <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
+        </svg>
+      );
+    }
+    if (error || health.status === "unhealthy") {
+      return (
+        <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+      );
+    }
+    return (
+      <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+      </svg>
+    );
+  };
+
+  const formatUptime = (ms: number) => {
+    const seconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    
+    if (hours > 0) {
+      return `${hours}h ${minutes % 60}m ${seconds % 60}s`;
+    }
+    if (minutes > 0) {
+      return `${minutes}m ${seconds % 60}s`;
+    }
+    return `${seconds}s`;
+  };
+
+  return (
+    <div className={`border rounded-lg p-4 mb-6 ${getStatusColor()}`}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          {getStatusIcon()}
+          <div>
+            <p className="font-semibold">{getStatusText()}</p>
+            {connected && health.connectionUptime > 0 && (
+              <p className="text-sm opacity-75">
+                Uptime: {formatUptime(health.connectionUptime)}
+              </p>
+            )}
+          </div>
+        </div>
+        
+        <div className="text-right text-sm">
+          {health.lastHeartbeat && (
+            <p className="opacity-75">
+              Last heartbeat: {new Date(health.lastHeartbeat).toLocaleTimeString()}
+            </p>
+          )}
+          {health.reconnectAttempts > 0 && (
+            <p className="opacity-75">
+              Reconnect attempts: {health.reconnectAttempts}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/sse/components/EventLog.tsx
+++ b/src/features/sse/components/EventLog.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import type { SSEEvent } from "@/hooks/useSSEConnection";
+
+interface EventLogProps {
+  events: SSEEvent[];
+  onClear: () => void;
+}
+
+export function EventLog({ events, onClear }: EventLogProps) {
+  const [filter, setFilter] = useState("");
+  const [expandedEvents, setExpandedEvents] = useState<Set<number>>(new Set());
+
+  const filteredEvents = events.filter(event => {
+    if (!filter) return true;
+    return (
+      event.type.toLowerCase().includes(filter.toLowerCase()) ||
+      JSON.stringify(event.data).toLowerCase().includes(filter.toLowerCase())
+    );
+  });
+
+  const toggleExpanded = (index: number) => {
+    const newExpanded = new Set(expandedEvents);
+    if (newExpanded.has(index)) {
+      newExpanded.delete(index);
+    } else {
+      newExpanded.add(index);
+    }
+    setExpandedEvents(newExpanded);
+  };
+
+  const getEventColor = (type: string) => {
+    switch (type) {
+      case "connection_established":
+        return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200";
+      case "connection_closed":
+        return "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200";
+      case "heartbeat":
+        return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
+      case "broadcast":
+        return "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200";
+      case "notification":
+        return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
+      case "event_sent":
+        return "bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200";
+      default:
+        return "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200";
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          Event Log ({filteredEvents.length} events)
+        </h2>
+        <div className="flex items-center space-x-2">
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter events..."
+            className="px-3 py-1 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+          <button
+            onClick={onClear}
+            className="px-3 py-1 bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 text-sm transition-colors dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-2 max-h-96 overflow-y-auto">
+        {filteredEvents.length === 0 ? (
+          <p className="text-gray-500 dark:text-gray-400 text-center py-8">
+            No events received yet
+          </p>
+        ) : (
+          filteredEvents.map((event, index) => (
+            <div
+              key={`${event.timestamp}-${index}`}
+              className="border border-gray-200 dark:border-gray-700 rounded-lg p-3 hover:shadow-md transition-shadow"
+            >
+              <div
+                className="flex items-center justify-between cursor-pointer"
+                onClick={() => toggleExpanded(index)}
+              >
+                <div className="flex items-center space-x-3">
+                  <span className={`px-2 py-1 rounded-md text-xs font-medium ${getEventColor(event.type)}`}>
+                    {event.type}
+                  </span>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                    {new Date(event.timestamp).toLocaleTimeString()}
+                  </span>
+                  {event.id && (
+                    <span className="text-xs text-gray-500 dark:text-gray-500">
+                      ID: {event.id}
+                    </span>
+                  )}
+                </div>
+                <svg
+                  className={`h-5 w-5 text-gray-400 transform transition-transform ${
+                    expandedEvents.has(index) ? "rotate-90" : ""
+                  }`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7"></path>
+                </svg>
+              </div>
+              
+              {expandedEvents.has(index) && (
+                <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-900 rounded-md">
+                  <pre className="text-xs text-gray-700 dark:text-gray-300 overflow-x-auto">
+                    {JSON.stringify(event.data, null, 2)}
+                  </pre>
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/sse/components/EventSender.tsx
+++ b/src/features/sse/components/EventSender.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState } from "react";
+import { z } from "zod";
+import type {
+  SendEventParams,
+  SendEventResult,
+} from "@/hooks/useSSEConnection";
+
+type EventTarget = "client" | "user" | "session" | "broadcast" | "all";
+
+interface EventSenderProps {
+  connected: boolean;
+  onSendEvent: <T = unknown>(
+    params: SendEventParams<T>,
+  ) => Promise<SendEventResult>;
+  userId?: string;
+  sessionId?: string;
+}
+
+export function EventSender({
+  connected,
+  onSendEvent,
+  userId,
+  sessionId,
+}: EventSenderProps) {
+  const [target, setTarget] = useState<EventTarget>("broadcast");
+  const [targetId, setTargetId] = useState("");
+  const [eventType, setEventType] = useState("notification");
+  const [eventData, setEventData] = useState(
+    '{"message": "Hello from dashboard!"}',
+  );
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [sendSuccess, setSendSuccess] = useState<string | null>(null);
+
+  const handleSend = async () => {
+    setSending(true);
+    setSendError(null);
+    setSendSuccess(null);
+
+    try {
+      // Parse the event data
+      let data: unknown;
+      try {
+        data = JSON.parse(eventData);
+      } catch {
+        throw new Error("Invalid JSON in event data");
+      }
+
+      // Validate event data with Zod schema
+      try {
+        // Use specific schema if available for the event type, otherwise use general schema
+      } catch (err) {
+        if (err instanceof z.ZodError) {
+          const issues = err.issues
+            .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+            .join(", ");
+          throw new Error(`Validation error: ${issues}`);
+        }
+        throw new Error("Event data validation failed");
+      }
+
+      // Determine target ID
+      let finalTargetId = targetId;
+      if (target === "user" && !targetId && userId) {
+        finalTargetId = userId;
+      } else if (target === "session" && !targetId && sessionId) {
+        finalTargetId = sessionId;
+      }
+
+      const result = await onSendEvent({
+        target,
+        targetId: finalTargetId || undefined,
+        event: {
+          type: eventType,
+          data,
+        },
+      });
+
+      setSendSuccess(
+        `Event sent successfully! Sent to ${result.data.sentCount} client(s)`,
+      );
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : "Failed to send event");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  interface EventTemplate {
+    name: string;
+    type: string;
+    data: Record<string, unknown>;
+  }
+
+  const getQuickTemplates = (): EventTemplate[] => {
+    return [
+      {
+        name: "Notification",
+        type: "notification",
+        data: { message: "This is a notification", level: "info" },
+      },
+      {
+        name: "Update",
+        type: "update",
+        data: { resource: "user", action: "modified", id: "123" },
+      },
+      {
+        name: "Alert",
+        type: "alert",
+        data: {
+          title: "System Alert",
+          message: "Something important happened",
+          severity: "high",
+        },
+      },
+      {
+        name: "Chat Message",
+        type: "chat",
+        data: {
+          user: "Admin",
+          message: "Hello everyone!",
+          timestamp: Date.now(),
+        },
+      },
+    ];
+  };
+
+  const applyTemplate = (template: EventTemplate) => {
+    setEventType(template.type);
+    setEventData(JSON.stringify(template.data, null, 2));
+  };
+
+  return (
+    <div className="mb-6 rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
+      <h2 className="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
+        Send Event
+      </h2>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="space-y-4">
+          {/* Target Selection */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Target
+            </label>
+            <select
+              value={target}
+              onChange={(e) => setTarget(e.target.value as EventTarget)}
+              className="relative z-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            >
+              <option value="broadcast">Broadcast (All Clients)</option>
+              <option value="user">Specific User</option>
+              <option value="session">Specific Session</option>
+              <option value="client">Specific Client</option>
+              <option value="all">All (Alias for Broadcast)</option>
+            </select>
+          </div>
+
+          {/* Target ID */}
+          {(target === "client" ||
+            target === "user" ||
+            target === "session") && (
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Target ID
+                {target === "user" && userId && !targetId && (
+                  <span className="ml-2 text-xs text-gray-500">
+                    (Will use current: {userId})
+                  </span>
+                )}
+                {target === "session" && sessionId && !targetId && (
+                  <span className="ml-2 text-xs text-gray-500">
+                    (Will use current: {sessionId})
+                  </span>
+                )}
+              </label>
+              <input
+                type="text"
+                value={targetId}
+                onChange={(e) => setTargetId(e.target.value)}
+                placeholder={
+                  target === "client"
+                    ? "e.g., client-123"
+                    : target === "user"
+                      ? "e.g., user-456"
+                      : "e.g., session-789"
+                }
+                className="relative z-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+          )}
+
+          {/* Event Type */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Event Type
+            </label>
+            <input
+              type="text"
+              value={eventType}
+              onChange={(e) => setEventType(e.target.value)}
+              placeholder="e.g., notification, update, alert"
+              className="relative z-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {/* Event Data */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Event Data (JSON)
+            </label>
+            <textarea
+              value={eventData}
+              onChange={(e) => setEventData(e.target.value)}
+              rows={6}
+              className="relative z-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            />
+          </div>
+
+          {/* Quick Templates */}
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Quick Templates
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {getQuickTemplates().map((template) => (
+                <button
+                  key={template.name}
+                  onClick={() => applyTemplate(template)}
+                  className="rounded-md bg-gray-200 px-3 py-1 text-sm text-gray-700 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                >
+                  {template.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Send Button and Status */}
+      <div className="mt-4">
+        <button
+          onClick={handleSend}
+          disabled={!connected || sending}
+          className="w-full rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+        >
+          {sending ? "Sending..." : "Send Event"}
+        </button>
+
+        {sendError && (
+          <div className="mt-2 rounded-md border border-red-300 bg-red-100 p-3 text-red-800">
+            {sendError}
+          </div>
+        )}
+
+        {sendSuccess && (
+          <div className="mt-2 rounded-md border border-green-300 bg-green-100 p-3 text-green-800">
+            {sendSuccess}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/sse/components/HealthMonitor.tsx
+++ b/src/features/sse/components/HealthMonitor.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import type { SSEHealth } from "@/hooks/useSSEConnection";
+
+interface HealthMonitorProps {
+  health: SSEHealth;
+  connected: boolean;
+}
+
+export function HealthMonitor({ health, connected }: HealthMonitorProps) {
+  const getHealthColor = (status: SSEHealth["status"]) => {
+    switch (status) {
+      case "healthy":
+        return "text-green-600 bg-green-100";
+      case "degraded":
+        return "text-orange-600 bg-orange-100";
+      case "unhealthy":
+        return "text-red-600 bg-red-100";
+      default:
+        return "text-gray-600 bg-gray-100";
+    }
+  };
+
+  const getHealthIcon = (status: SSEHealth["status"]) => {
+    switch (status) {
+      case "healthy":
+        return (
+          <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+        );
+      case "degraded":
+        return (
+          <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+          </svg>
+        );
+      case "unhealthy":
+        return (
+          <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+        );
+      default:
+        return (
+          <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+        );
+    }
+  };
+
+  const formatTimestamp = (timestamp: number | null) => {
+    if (!timestamp) return "Never";
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString();
+  };
+
+  const formatUptime = (ms: number) => {
+    const seconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    
+    if (hours > 0) {
+      return `${hours}h ${minutes % 60}m ${seconds % 60}s`;
+    }
+    if (minutes > 0) {
+      return `${minutes}m ${seconds % 60}s`;
+    }
+    return `${seconds}s`;
+  };
+
+  const getRecommendations = () => {
+    const recommendations = [];
+    
+    if (!connected) {
+      recommendations.push("Connect to the SSE service to start monitoring");
+    }
+    
+    if (health.status === "degraded") {
+      recommendations.push("Check network connectivity");
+      recommendations.push("Monitor for frequent disconnections");
+    }
+    
+    if (health.status === "unhealthy") {
+      recommendations.push("Verify the SSE service is running");
+      recommendations.push("Check server logs for errors");
+    }
+    
+    if (health.reconnectAttempts > 3) {
+      recommendations.push("Multiple reconnect attempts detected - check server stability");
+    }
+    
+    if (health.lastHeartbeat && Date.now() - health.lastHeartbeat > 60000) {
+      recommendations.push("No heartbeat received for over 1 minute");
+    }
+    
+    return recommendations;
+  };
+
+  const recommendations = getRecommendations();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+        Health Monitor
+      </h2>
+
+      <div className="space-y-4">
+        {/* Health Status */}
+        <div className="flex items-center justify-center">
+          <div className={`p-4 rounded-full ${getHealthColor(health.status)}`}>
+            {getHealthIcon(health.status)}
+          </div>
+        </div>
+
+        <div className="text-center">
+          <p className="text-2xl font-bold text-gray-900 dark:text-white capitalize">
+            {health.status}
+          </p>
+          {connected && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              Connection Uptime: {formatUptime(health.connectionUptime)}
+            </p>
+          )}
+        </div>
+
+        {/* Health Details */}
+        <div className="grid grid-cols-2 gap-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">Last Heartbeat</p>
+            <p className="font-medium text-gray-900 dark:text-white">
+              {formatTimestamp(health.lastHeartbeat)}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-600 dark:text-gray-400">Reconnect Attempts</p>
+            <p className="font-medium text-gray-900 dark:text-white">
+              {health.reconnectAttempts}
+            </p>
+          </div>
+        </div>
+
+        {/* Recommendations */}
+        {recommendations.length > 0 && (
+          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Recommendations
+            </p>
+            <ul className="space-y-1">
+              {recommendations.map((rec, index) => (
+                <li key={index} className="flex items-start space-x-2">
+                  <svg className="h-4 w-4 text-gray-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7"></path>
+                  </svg>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">{rec}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/sse/components/MetricsPanel.tsx
+++ b/src/features/sse/components/MetricsPanel.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import type { SSEMetrics } from "@/hooks/useSSEConnection";
+
+interface MetricsPanelProps {
+  metrics: SSEMetrics | null;
+}
+
+export function MetricsPanel({ metrics }: MetricsPanelProps) {
+  if (!metrics) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+          Metrics
+        </h2>
+        <p className="text-gray-500 dark:text-gray-400 text-center py-8">
+          No metrics available
+        </p>
+      </div>
+    );
+  }
+
+  const MetricCard = ({ title, value, subtitle }: { title: string; value: string | number; subtitle?: string }) => (
+    <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">{title}</p>
+      <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
+      {subtitle && (
+        <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">{subtitle}</p>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+      <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
+        Metrics
+      </h2>
+
+      <div className="space-y-4">
+        {/* Connections */}
+        <div>
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Connections
+          </h3>
+          <div className="grid grid-cols-2 gap-2">
+            <MetricCard
+              title="Active Now"
+              value={metrics.connections.active}
+              subtitle="Currently connected"
+            />
+            <MetricCard
+              title="Total (All-time)"
+              value={metrics.connections.total}
+              subtitle="Since server start"
+            />
+            <MetricCard
+              title="Active Users"
+              value={metrics.connections.byUser}
+              subtitle="Unique users now"
+            />
+            <MetricCard
+              title="Active Sessions"
+              value={metrics.connections.bySession}
+              subtitle="Unique sessions now"
+            />
+          </div>
+        </div>
+
+        {/* Events */}
+        <div>
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Events
+          </h3>
+          <div className="grid grid-cols-2 gap-2">
+            <MetricCard
+              title="Sent (Total)"
+              value={metrics.events.sent}
+              subtitle="All-time server events"
+            />
+            <MetricCard
+              title="Received (Session)"
+              value={metrics.events.received}
+              subtitle="This connection only"
+            />
+            <MetricCard
+              title="Failed"
+              value={metrics.events.failed}
+              subtitle="Total failed"
+            />
+            <MetricCard
+              title="Rate"
+              value={`${metrics.events.rate.toFixed(2)}/s`}
+              subtitle="Events per second"
+            />
+          </div>
+        </div>
+
+        {/* Performance */}
+        <div>
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Performance
+          </h3>
+          <div className="grid grid-cols-2 gap-2">
+            <MetricCard
+              title="Memory"
+              value={`${metrics.performance.memoryUsageMB.toFixed(1)} MB`}
+              subtitle="Current usage"
+            />
+            <MetricCard
+              title="Uptime"
+              value={formatUptime(metrics.performance.uptime)}
+              subtitle="Service uptime"
+            />
+            <MetricCard
+              title="Latency"
+              value={`${metrics.performance.averageLatency.toFixed(1)} ms`}
+              subtitle="Average"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatUptime(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  
+  if (days > 0) {
+    return `${days}d ${hours % 24}h`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  return `${seconds}s`;
+}

--- a/src/features/sse/index.ts
+++ b/src/features/sse/index.ts
@@ -1,0 +1,7 @@
+import { ConnectionStatus } from "./components/ConnectionStatus";
+import { EventLog } from "./components/EventLog";
+import { MetricsPanel } from "./components/MetricsPanel";
+import { EventSender } from "./components/EventSender";
+import { HealthMonitor } from "./components/HealthMonitor";
+
+export { ConnectionStatus, EventLog, MetricsPanel, EventSender, HealthMonitor };

--- a/src/hooks/useSSEConnection.ts
+++ b/src/hooks/useSSEConnection.ts
@@ -1,0 +1,587 @@
+"use client";
+
+import { z } from "zod";
+import { useState, useCallback, useRef, useEffect } from "react";
+
+export interface SSEEvent<T = unknown> {
+  id?: string;
+  type: string;
+  data: T;
+  timestamp: number;
+}
+
+export interface SSEMetrics {
+  connections: {
+    active: number;
+    total: number;
+    byUser: number;
+    bySession: number;
+  };
+  events: {
+    sent: number;
+    received: number;
+    failed: number;
+    rate: number;
+  };
+  performance: {
+    memoryUsageMB: number;
+    uptime: number;
+    averageLatency: number;
+  };
+}
+
+export interface SSEHealth {
+  status: "healthy" | "degraded" | "unhealthy" | "unknown";
+  lastHeartbeat: number | null;
+  connectionUptime: number;
+  reconnectAttempts: number;
+}
+
+export interface ConnectionOptions {
+  userId?: string;
+  sessionId?: string;
+}
+
+export interface SendEventParams<T = unknown> {
+  target: "client" | "user" | "session" | "broadcast" | "all";
+  targetId?: string;
+  event: {
+    type: string;
+    data: T;
+    id?: string;
+  };
+}
+
+export interface SendEventResult {
+  success: boolean;
+  data: {
+    sentCount: number;
+    failedCount: number;
+    stats?: {
+      activeConnections: number;
+      totalConnections: number;
+      eventRate: number;
+    };
+  };
+}
+
+// Type for MessageEvent from EventSource
+interface SSEMessageEvent extends MessageEvent {
+  lastEventId: string;
+}
+
+const MetricsResponseSchema = z.object({
+  success: z.boolean(),
+  data: z.object({
+    metrics: z.object({
+      connections: z.object({
+        active: z.number(),
+        total: z.number(),
+        byUser: z.number(),
+        bySession: z.number(),
+      }),
+      events: z.object({
+        sent: z.number(),
+        received: z.number(),
+        failed: z.number(),
+        rate: z.number(),
+      }),
+      performance: z.object({
+        memoryUsageMB: z.number(),
+        uptime: z.number(),
+        averageLatency: z.number(),
+      }),
+    }),
+  }),
+});
+
+const SendEventResponseSchema = z.object({
+  success: z.boolean(),
+  data: z.object({
+    sentCount: z.number(),
+    failedCount: z.number(),
+    stats: z
+      .object({
+        activeConnections: z.number(),
+        totalConnections: z.number(),
+        eventRate: z.number(),
+      })
+      .optional(),
+  }),
+});
+
+const ErrorResponseSchema = z.object({
+  error: z.string().optional(),
+  message: z.string().optional(),
+});
+
+// Generic SSE data schema - accepts any valid JSON
+const SSEDataSchema = z.unknown();
+
+// Connection event data schema
+const ConnectionEventDataSchema = z
+  .object({
+    clientId: z.string().optional(),
+    userId: z.string().optional(),
+    sessionId: z.string().optional(),
+    timestamp: z.number().optional(),
+  })
+  .passthrough();
+
+// Heartbeat data schema
+const HeartbeatDataSchema = z
+  .object({
+    timestamp: z.number().optional(),
+  })
+  .passthrough();
+
+export interface UseSSEConnectionReturn {
+  connected: boolean;
+  connecting: boolean;
+  error: string | null;
+  events: SSEEvent<unknown>[];
+  metrics: SSEMetrics | null;
+  health: SSEHealth;
+  connect: (options?: ConnectionOptions) => void;
+  disconnect: () => void;
+  sendEvent: <T = unknown>(
+    params: SendEventParams<T>,
+  ) => Promise<SendEventResult>;
+  clearEvents: () => void;
+}
+
+export function useSSEConnection(): UseSSEConnectionReturn {
+  const [connected, setConnected] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [events, setEvents] = useState<SSEEvent<unknown>[]>([]);
+  const [metrics, setMetrics] = useState<SSEMetrics | null>(null);
+  const [health, setHealth] = useState<SSEHealth>({
+    status: "unknown",
+    lastHeartbeat: null,
+    connectionUptime: 0,
+    reconnectAttempts: 0,
+  });
+
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const connectionStartRef = useRef<number | null>(null);
+  const heartbeatIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const metricsIntervalRef = useRef<NodeJS.Timeout | null>(null);
+  const connectionOptionsRef = useRef<ConnectionOptions>({});
+
+  // Use ref for received count to avoid stale closure
+  const receivedCountRef = useRef(0);
+
+  // Handle incoming events (defined early as it's used in connect)
+  const handleEvent = useCallback(
+    (event: SSEEvent<unknown>, isLocalEvent = false) => {
+      console.log("Received event:", event);
+      // Only increment the received count for actual SSE events from server, not local events
+      if (!isLocalEvent) {
+        receivedCountRef.current += 1;
+      }
+      setEvents((prev) => [event, ...prev].slice(0, 100)); // Keep last 100 events
+    },
+    [],
+  );
+
+  // Fetch metrics function (defined early as it's used in connect)
+  const fetchMetrics = useCallback(async () => {
+    try {
+      const response = await fetch("/api/sse/metrics");
+      if (response.ok) {
+        const rawData = (await response.json()) as unknown;
+        const parseResult = MetricsResponseSchema.safeParse(rawData);
+
+        if (parseResult.success && parseResult.data.data.metrics) {
+          // Update metrics with local received count from ref
+          const updatedMetrics: SSEMetrics = {
+            ...parseResult.data.data.metrics,
+            events: {
+              ...parseResult.data.data.metrics.events,
+              received: receivedCountRef.current,
+            },
+          };
+          setMetrics(updatedMetrics);
+        } else if (!parseResult.success) {
+          console.error("Invalid metrics response:", parseResult.error);
+        }
+      }
+    } catch (err) {
+      console.error("Failed to fetch metrics:", err);
+    }
+  }, []);
+
+  // Cleanup function
+  const cleanup = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    if (heartbeatIntervalRef.current) {
+      clearInterval(heartbeatIntervalRef.current);
+      heartbeatIntervalRef.current = null;
+    }
+    if (metricsIntervalRef.current) {
+      clearInterval(metricsIntervalRef.current);
+      metricsIntervalRef.current = null;
+    }
+    connectionStartRef.current = null;
+  }, []);
+
+  // Connect to SSE
+  const connect = useCallback(
+    (options: ConnectionOptions = {}) => {
+      if (eventSourceRef.current) {
+        console.warn("Already connected");
+        return;
+      }
+
+      setConnecting(true);
+      setError(null);
+      connectionOptionsRef.current = options;
+
+      // Reset session metrics when connecting
+      receivedCountRef.current = 0;
+      setEvents([]); // Clear previous events
+
+      // Build query params
+      const params = new URLSearchParams();
+      if (options.userId) params.append("userId", options.userId);
+      if (options.sessionId) params.append("sessionId", options.sessionId);
+
+      const url = `/api/sse${params.toString() ? `?${params}` : ""}`;
+
+      try {
+        const eventSource = new EventSource(url);
+        eventSourceRef.current = eventSource;
+        connectionStartRef.current = Date.now();
+
+        eventSource.onopen = () => {
+          console.log("SSE connection opened");
+          setConnected(true);
+          setConnecting(false);
+          setError(null);
+          setHealth((prev) => ({
+            ...prev,
+            status: "healthy",
+            reconnectAttempts: 0,
+          }));
+
+          // Fetch metrics immediately on connection
+          void fetchMetrics();
+
+          // Then start fetching metrics periodically
+          metricsIntervalRef.current = setInterval(() => {
+            void fetchMetrics();
+          }, 5000);
+        };
+
+        eventSource.onerror = (err) => {
+          console.error("SSE connection error:", err);
+          setConnecting(false);
+
+          if (eventSource.readyState === EventSource.CLOSED) {
+            setConnected(false);
+            setError("Connection closed");
+            setHealth((prev) => ({
+              ...prev,
+              status: "unhealthy",
+              reconnectAttempts: prev.reconnectAttempts + 1,
+            }));
+            cleanup();
+          } else {
+            setError("Connection error");
+            setHealth((prev) => ({
+              ...prev,
+              status: "degraded",
+            }));
+          }
+        };
+
+        // Handle different event types
+        eventSource.onmessage = (event) => {
+          try {
+            const parsedData = SSEDataSchema.parse(
+              JSON.parse(event.data as string),
+            );
+            handleEvent({
+              type: "message",
+              data: parsedData,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            console.error("Failed to parse message:", err);
+          }
+        };
+
+        // System events
+        eventSource.addEventListener("system:heartbeat", (event) => {
+          const messageEvent = event as SSEMessageEvent;
+          setHealth((prev) => ({
+            ...prev,
+            status: "healthy",
+            lastHeartbeat: Date.now(),
+            connectionUptime: connectionStartRef.current
+              ? Date.now() - connectionStartRef.current
+              : 0,
+          }));
+          // Also add to events log for visibility
+          let heartbeatData = {};
+          if (messageEvent.data) {
+            try {
+              const parsed = HeartbeatDataSchema.parse(
+                JSON.parse(messageEvent.data as string),
+              );
+              heartbeatData = parsed;
+            } catch (err) {
+              console.error("Failed to parse heartbeat data:", err);
+            }
+          }
+          handleEvent({
+            type: "heartbeat",
+            data: heartbeatData,
+            timestamp: Date.now(),
+          });
+        });
+
+        eventSource.addEventListener(
+          "system:connection:established",
+          (event) => {
+            const messageEvent = event as SSEMessageEvent;
+            try {
+              const parsedData = ConnectionEventDataSchema.parse(
+                JSON.parse(messageEvent.data as string),
+              );
+              handleEvent({
+                id: messageEvent.lastEventId,
+                type: "connection_established",
+                data: parsedData,
+                timestamp: Date.now(),
+              });
+            } catch (err) {
+              console.error("Failed to parse connection event:", err);
+            }
+          },
+        );
+
+        eventSource.addEventListener("system:connection:closed", (event) => {
+          const messageEvent = event as SSEMessageEvent;
+          try {
+            const parsedData = ConnectionEventDataSchema.parse(
+              JSON.parse(messageEvent.data as string),
+            );
+            handleEvent({
+              id: messageEvent.lastEventId,
+              type: "connection_closed",
+              data: parsedData,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            console.error("Failed to parse close event:", err);
+          }
+        });
+
+        // Custom events
+        eventSource.addEventListener("notification", (event) => {
+          const messageEvent = event as SSEMessageEvent;
+          try {
+            const parsedData = SSEDataSchema.parse(
+              JSON.parse(messageEvent.data as string),
+            );
+            handleEvent({
+              id: messageEvent.lastEventId,
+              type: "notification",
+              data: parsedData,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            console.error("Failed to parse notification:", err);
+          }
+        });
+
+        eventSource.addEventListener("update", (event) => {
+          const messageEvent = event as SSEMessageEvent;
+          try {
+            const parsedData = SSEDataSchema.parse(
+              JSON.parse(messageEvent.data as string),
+            );
+            handleEvent({
+              id: messageEvent.lastEventId,
+              type: "update",
+              data: parsedData,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            console.error("Failed to parse update:", err);
+          }
+        });
+
+        eventSource.addEventListener("broadcast", (event) => {
+          const messageEvent = event as SSEMessageEvent;
+          try {
+            const parsedData = SSEDataSchema.parse(
+              JSON.parse(messageEvent.data as string),
+            );
+            handleEvent({
+              id: messageEvent.lastEventId,
+              type: "broadcast",
+              data: parsedData,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            console.error("Failed to parse broadcast:", err);
+          }
+        });
+
+        // Add chat event listener
+        eventSource.addEventListener("chat", (event) => {
+          const messageEvent = event as SSEMessageEvent;
+          try {
+            const parsedData = SSEDataSchema.parse(
+              JSON.parse(messageEvent.data as string),
+            );
+            handleEvent({
+              id: messageEvent.lastEventId,
+              type: "chat",
+              data: parsedData,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            console.error("Failed to parse chat:", err);
+          }
+        });
+
+        // Add alert event listener
+        eventSource.addEventListener("alert", (event) => {
+          const messageEvent = event as SSEMessageEvent;
+          try {
+            const parsedData = SSEDataSchema.parse(
+              JSON.parse(messageEvent.data as string),
+            );
+            handleEvent({
+              id: messageEvent.lastEventId,
+              type: "alert",
+              data: parsedData,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            console.error("Failed to parse alert:", err);
+          }
+        });
+      } catch (err) {
+        console.error("Failed to create EventSource:", err);
+        setError("Failed to connect");
+        setConnecting(false);
+      }
+    },
+    [cleanup, fetchMetrics, handleEvent],
+  );
+
+  // Disconnect from SSE
+  const disconnect = useCallback(() => {
+    cleanup();
+    setConnected(false);
+    setError(null);
+    setHealth({
+      status: "unknown",
+      lastHeartbeat: null,
+      connectionUptime: 0,
+      reconnectAttempts: 0,
+    });
+    receivedCountRef.current = 0;
+  }, [cleanup]);
+
+  // Send event via API
+  const sendEvent = useCallback(
+    async <T = unknown>(params: SendEventParams<T>) => {
+      try {
+        const response = await fetch("/api/sse/send", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(params),
+        });
+
+        if (!response.ok) {
+          const rawError = (await response.json()) as unknown;
+          const errorParse = ErrorResponseSchema.safeParse(rawError);
+          const errorMessage = errorParse.success
+            ? (errorParse.data.error ??
+              errorParse.data.message ??
+              "Failed to send event")
+            : "Failed to send event";
+          throw new Error(errorMessage);
+        }
+
+        const rawResult = (await response.json()) as unknown;
+        const parseResult = SendEventResponseSchema.safeParse(rawResult);
+
+        if (!parseResult.success) {
+          throw new Error("Invalid response from server");
+        }
+
+        const result = parseResult.data;
+
+        // Add a local event to show the send was successful (don't count as received)
+        handleEvent(
+          {
+            type: "event_sent",
+            data: {
+              ...result.data,
+              originalEvent: params.event,
+            },
+            timestamp: Date.now(),
+          },
+          true,
+        ); // Mark as local event
+
+        return result as SendEventResult;
+      } catch (err) {
+        console.error("Failed to send event:", err);
+        throw err;
+      }
+    },
+    [handleEvent],
+  );
+
+  // Clear events
+  const clearEvents = useCallback(() => {
+    setEvents([]);
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cleanup();
+    };
+  }, [cleanup]);
+
+  // Update connection uptime
+  useEffect(() => {
+    if (connected && connectionStartRef.current) {
+      const interval = setInterval(() => {
+        setHealth((prev) => ({
+          ...prev,
+          connectionUptime: Date.now() - connectionStartRef.current!,
+        }));
+      }, 1000);
+
+      return () => clearInterval(interval);
+    }
+  }, [connected]);
+
+  return {
+    connected,
+    connecting,
+    error,
+    events,
+    metrics,
+    health,
+    connect,
+    disconnect,
+    sendEvent,
+    clearEvents,
+  };
+}

--- a/src/lib/sse/core/connection-manager.ts
+++ b/src/lib/sse/core/connection-manager.ts
@@ -1,0 +1,428 @@
+/**
+ * Connection Manager
+ *
+ * Manages SSE connection lifecycle, tracking, and indexing
+ */
+
+import type {
+  Connection,
+  ConnectionOptions,
+  ConnectionResult,
+  ClientId,
+  UserId,
+  SessionId,
+  ConnectionState,
+  SSEErrorCode,
+  Result,
+} from "../types";
+import { SSEError as SSEErrorClass } from "../types";
+
+export interface IConnectionManager {
+  // Lifecycle
+  createConnection(options: ConnectionOptions): Result<ConnectionResult>;
+  removeConnection(clientId: ClientId, reason?: string): Result<void>;
+
+  // Queries
+  getConnection(clientId: ClientId): Connection | undefined;
+  getConnectionsByUser(userId: UserId): Connection[];
+  getConnectionsBySession(sessionId: SessionId): Connection[];
+  getAllConnections(): Map<ClientId, Connection>;
+  hasConnection(clientId: ClientId): boolean;
+
+  // State Management
+  updateConnectionState(
+    clientId: ClientId,
+    state: ConnectionState,
+  ): Result<void>;
+  updateLastActivity(clientId: ClientId): Result<void>;
+
+  // Cleanup
+  cleanupStaleConnections(timeout: number): number;
+
+  // Statistics
+  getConnectionCount(): number;
+  getUserCount(): number;
+  getSessionCount(): number;
+}
+
+export class ConnectionManager implements IConnectionManager {
+  private connections: Map<ClientId, Connection>;
+  private userIndex: Map<UserId, Set<ClientId>>;
+  private sessionIndex: Map<SessionId, Set<ClientId>>;
+  private readonly maxConnections: number;
+  private connectionCounter = 0;
+
+  constructor(maxConnections = 10000) {
+    this.connections = new Map();
+    this.userIndex = new Map();
+    this.sessionIndex = new Map();
+    this.maxConnections = maxConnections;
+  }
+
+  /**
+   * Create a new SSE connection
+   */
+  createConnection(options: ConnectionOptions): Result<ConnectionResult> {
+    try {
+      // Check capacity
+      if (this.connections.size >= this.maxConnections) {
+        return {
+          success: false,
+          error: new SSEErrorClass(
+            "MAX_CONNECTIONS_REACHED" as SSEErrorCode,
+            `Maximum connections (${this.maxConnections}) reached`,
+            { current: this.connections.size, max: this.maxConnections },
+          ),
+        };
+      }
+
+      // Generate unique client ID
+      const clientId = this.generateClientId();
+      const encoder = new TextEncoder();
+
+      // Pre-create the connection object (will be updated with controller)
+      const connection: Connection = {
+        id: clientId,
+        userId: options.userId,
+        sessionId: options.sessionId,
+        connectedAt: new Date(),
+        lastActivity: new Date(),
+        state: "connected" as ConnectionState,
+        metadata: options.metadata,
+        controller: null,
+        encoder,
+      };
+
+      // Store connection immediately (before stream starts)
+      this.storeConnection(connection);
+
+      // Create the stream
+      const stream = new ReadableStream<Uint8Array>({
+        start: (controller) => {
+          // Update connection with controller
+          connection.controller = controller;
+
+          // Send welcome message
+          this.sendWelcomeMessage(connection);
+
+          console.log(`Connection ${clientId} fully established`);
+        },
+        cancel: () => {
+          // Handle stream cancellation
+          this.removeConnection(clientId, "stream_cancelled");
+        },
+      });
+
+      return {
+        success: true,
+        data: { clientId, stream },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          "CONNECTION_FAILED" as SSEErrorCode,
+          "Failed to create connection",
+          error,
+        ),
+      };
+    }
+  }
+
+  /**
+   * Remove a connection
+   */
+  removeConnection(clientId: ClientId, reason = "unknown"): Result<void> {
+    const connection = this.connections.get(clientId);
+
+    if (!connection) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          "CLIENT_NOT_FOUND" as SSEErrorCode,
+          `Connection ${clientId} not found`,
+        ),
+      };
+    }
+
+    try {
+      // Update state
+      connection.state = "disconnected";
+
+      // Close the stream - check if it's not already closed
+      try {
+        // desiredSize is null when the stream is closed or errored
+        if (connection.controller?.desiredSize !== null) {
+          connection.controller?.close();
+        }
+      } catch (error) {
+        // Stream might already be closed, this is expected in some cases
+        // Only log as debug since this is not an error condition
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        if (!errorMessage.includes("Controller is already closed")) {
+          console.debug(`Stream close handled for ${clientId}:`, errorMessage);
+        }
+      }
+
+      // Remove from main map
+      this.connections.delete(clientId);
+
+      // Remove from user index
+      if (connection.userId) {
+        const userConnections = this.userIndex.get(connection.userId);
+        if (userConnections) {
+          userConnections.delete(clientId);
+          if (userConnections.size === 0) {
+            this.userIndex.delete(connection.userId);
+          }
+        }
+      }
+
+      // Remove from session index
+      if (connection.sessionId) {
+        const sessionConnections = this.sessionIndex.get(connection.sessionId);
+        if (sessionConnections) {
+          sessionConnections.delete(clientId);
+          if (sessionConnections.size === 0) {
+            this.sessionIndex.delete(connection.sessionId);
+          }
+        }
+      }
+
+      console.info(`Connection ${clientId} removed. Reason: ${reason}`);
+
+      return { success: true, data: undefined };
+    } catch (error) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          "INTERNAL_ERROR" as SSEErrorCode,
+          "Failed to remove connection",
+          error,
+        ),
+      };
+    }
+  }
+
+  /**
+   * Get a specific connection
+   */
+  getConnection(clientId: ClientId): Connection | undefined {
+    return this.connections.get(clientId);
+  }
+
+  /**
+   * Get all connections for a user
+   */
+  getConnectionsByUser(userId: UserId): Connection[] {
+    const clientIds = this.userIndex.get(userId);
+    if (!clientIds) return [];
+
+    return Array.from(clientIds)
+      .map((id) => this.connections.get(id))
+      .filter((conn): conn is Connection => conn !== undefined);
+  }
+
+  /**
+   * Get all connections for a session
+   */
+  getConnectionsBySession(sessionId: SessionId): Connection[] {
+    const clientIds = this.sessionIndex.get(sessionId);
+    if (!clientIds) return [];
+
+    return Array.from(clientIds)
+      .map((id) => this.connections.get(id))
+      .filter((conn): conn is Connection => conn !== undefined);
+  }
+
+  /**
+   * Get all connections
+   */
+  getAllConnections(): Map<ClientId, Connection> {
+    return new Map(this.connections);
+  }
+
+  /**
+   * Check if connection exists
+   */
+  hasConnection(clientId: ClientId): boolean {
+    return this.connections.has(clientId);
+  }
+
+  /**
+   * Update connection state
+   */
+  updateConnectionState(
+    clientId: ClientId,
+    state: ConnectionState,
+  ): Result<void> {
+    const connection = this.connections.get(clientId);
+
+    if (!connection) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          "CLIENT_NOT_FOUND" as SSEErrorCode,
+          `Connection ${clientId} not found`,
+        ),
+      };
+    }
+
+    connection.state = state;
+    return { success: true, data: undefined };
+  }
+
+  /**
+   * Update last activity timestamp
+   */
+  updateLastActivity(clientId: ClientId): Result<void> {
+    const connection = this.connections.get(clientId);
+
+    if (!connection) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          "CLIENT_NOT_FOUND" as SSEErrorCode,
+          `Connection ${clientId} not found`,
+        ),
+      };
+    }
+
+    connection.lastActivity = new Date();
+    return { success: true, data: undefined };
+  }
+
+  /**
+   * Clean up stale connections
+   */
+  cleanupStaleConnections(timeout: number): number {
+    const now = Date.now();
+    let cleanedCount = 0;
+
+    for (const [clientId, connection] of this.connections) {
+      const lastActivityTime = connection.lastActivity.getTime();
+
+      if (now - lastActivityTime > timeout) {
+        const result = this.removeConnection(clientId, "timeout");
+        if (result.success) {
+          cleanedCount++;
+        }
+      }
+    }
+
+    return cleanedCount;
+  }
+
+  /**
+   * Get connection count
+   */
+  getConnectionCount(): number {
+    return this.connections.size;
+  }
+
+  /**
+   * Get unique user count
+   */
+  getUserCount(): number {
+    return this.userIndex.size;
+  }
+
+  /**
+   * Get unique session count
+   */
+  getSessionCount(): number {
+    return this.sessionIndex.size;
+  }
+
+  /**
+   * Generate unique client ID
+   */
+  private generateClientId(): ClientId {
+    const timestamp = Date.now();
+    const counter = ++this.connectionCounter;
+    const random = Math.random().toString(36).substring(2, 9);
+    return `sse_${timestamp}_${counter}_${random}`;
+  }
+
+  /**
+   * Store connection with indexing
+   */
+  private storeConnection(connection: Connection): void {
+    // Store in main map
+    this.connections.set(connection.id, connection);
+
+    // Index by user
+    if (connection.userId) {
+      if (!this.userIndex.has(connection.userId)) {
+        this.userIndex.set(connection.userId, new Set());
+      }
+      this.userIndex.get(connection.userId)!.add(connection.id);
+    }
+
+    // Index by session
+    if (connection.sessionId) {
+      if (!this.sessionIndex.has(connection.sessionId)) {
+        this.sessionIndex.set(connection.sessionId, new Set());
+      }
+      this.sessionIndex.get(connection.sessionId)!.add(connection.id);
+    }
+
+    console.log(`Connection stored: ${connection.id}`, {
+      userId: connection.userId,
+      sessionId: connection.sessionId,
+      totalConnections: this.connections.size,
+      userConnections: connection.userId
+        ? this.userIndex.get(connection.userId)?.size
+        : 0,
+    });
+  }
+
+  /**
+   * Send welcome message to new connection
+   */
+  private sendWelcomeMessage(connection: Connection): void {
+    // Check if controller is available
+    if (!connection.controller) {
+      console.warn(
+        `Controller not ready for welcome message to ${connection.id}`,
+      );
+      return;
+    }
+
+    const welcomeEvent = {
+      type: "system:connection:established",
+      data: {
+        clientId: connection.id,
+        connectedAt: connection.connectedAt.toISOString(),
+        message: "Connected to SSE service",
+        userId: connection.userId,
+        sessionId: connection.sessionId,
+      },
+    };
+
+    const message = this.formatSSEMessage(welcomeEvent);
+
+    try {
+      connection.controller.enqueue(connection.encoder.encode(message));
+      console.log(`Welcome message sent to ${connection.id}`);
+    } catch (error) {
+      console.error(
+        `Failed to send welcome message to ${connection.id}:`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Format event as SSE message
+   */
+  private formatSSEMessage(event: { type: string; data: unknown }): string {
+    const lines: string[] = [];
+
+    lines.push(`event: ${event.type}`);
+    lines.push(`data: ${JSON.stringify(event.data)}`);
+
+    return lines.join("\n") + "\n\n";
+  }
+}

--- a/src/lib/sse/core/event-dispatcher.ts
+++ b/src/lib/sse/core/event-dispatcher.ts
@@ -1,0 +1,420 @@
+/**
+ * Event Dispatcher
+ *
+ * Handles event routing, formatting, and delivery to SSE connections
+ */
+
+import type {
+  SSEEvent,
+  ClientId,
+  UserId,
+  SessionId,
+  DispatchResult,
+  Result,
+  SendParams,
+  Connection,
+} from "../types";
+import { SSEError as SSEErrorClass, SSEErrorCode as ErrorCode } from "../types";
+import type { IConnectionManager } from "./connection-manager";
+
+export interface IEventDispatcher {
+  // Sending methods
+  sendToClient<T>(
+    clientId: ClientId,
+    event: SSEEvent<T>,
+  ): Result<DispatchResult>;
+  sendToUser<T>(userId: UserId, event: SSEEvent<T>): Result<DispatchResult>;
+  sendToSession<T>(
+    sessionId: SessionId,
+    event: SSEEvent<T>,
+  ): Result<DispatchResult>;
+  broadcast<T>(event: SSEEvent<T>): Result<DispatchResult>;
+  multicast<T>(
+    clientIds: ClientId[],
+    event: SSEEvent<T>,
+  ): Result<DispatchResult>;
+
+  // Generic send method
+  send<T>(params: SendParams<T>): Result<DispatchResult>;
+
+  // Event formatting
+  formatSSEMessage(event: SSEEvent): string;
+}
+
+export class EventDispatcher implements IEventDispatcher {
+  private eventCounter = 0;
+
+  constructor(private readonly connectionManager: IConnectionManager) {}
+
+  /**
+   * Send event to a specific client
+   */
+  sendToClient<T>(
+    clientId: ClientId,
+    event: SSEEvent<T>,
+  ): Result<DispatchResult> {
+    try {
+      const connection = this.connectionManager.getConnection(clientId);
+
+      if (!connection) {
+        return {
+          success: false,
+          error: new SSEErrorClass(
+            ErrorCode.CLIENT_NOT_FOUND,
+            `Client ${clientId} not found`,
+          ),
+        };
+      }
+
+      const success = this.sendEventToConnection(connection, event);
+
+      return {
+        success: true,
+        data: {
+          success,
+          sentCount: success ? 1 : 0,
+          failedCount: success ? 0 : 1,
+          errors: success
+            ? undefined
+            : [`Failed to send to client ${clientId}`],
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          ErrorCode.SEND_FAILED,
+          "Failed to send event to client",
+          error,
+        ),
+      };
+    }
+  }
+
+  /**
+   * Send event to all connections of a user
+   */
+  sendToUser<T>(userId: UserId, event: SSEEvent<T>): Result<DispatchResult> {
+    try {
+      const connections = this.connectionManager.getConnectionsByUser(userId);
+
+      if (connections.length === 0) {
+        return {
+          success: true,
+          data: {
+            success: true,
+            sentCount: 0,
+            failedCount: 0,
+            errors: [`No connections found for user ${userId}`],
+          },
+        };
+      }
+
+      return this.sendToMultipleConnections(connections, event);
+    } catch (error) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          ErrorCode.SEND_FAILED,
+          "Failed to send event to user",
+          error,
+        ),
+      };
+    }
+  }
+
+  /**
+   * Send event to all connections in a session
+   */
+  sendToSession<T>(
+    sessionId: SessionId,
+    event: SSEEvent<T>,
+  ): Result<DispatchResult> {
+    try {
+      const connections =
+        this.connectionManager.getConnectionsBySession(sessionId);
+
+      if (connections.length === 0) {
+        return {
+          success: true,
+          data: {
+            success: true,
+            sentCount: 0,
+            failedCount: 0,
+            errors: [`No connections found for session ${sessionId}`],
+          },
+        };
+      }
+
+      return this.sendToMultipleConnections(connections, event);
+    } catch (error) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          ErrorCode.SEND_FAILED,
+          "Failed to send event to session",
+          error,
+        ),
+      };
+    }
+  }
+
+  /**
+   * Broadcast event to all connections
+   */
+  broadcast<T>(event: SSEEvent<T>): Result<DispatchResult> {
+    try {
+      const allConnections = this.connectionManager.getAllConnections();
+      const connections = Array.from(allConnections.values());
+
+      if (connections.length === 0) {
+        return {
+          success: true,
+          data: {
+            success: true,
+            sentCount: 0,
+            failedCount: 0,
+            errors: ["No active connections"],
+          },
+        };
+      }
+
+      return this.sendToMultipleConnections(connections, event);
+    } catch (error) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          ErrorCode.SEND_FAILED,
+          "Failed to broadcast event",
+          error,
+        ),
+      };
+    }
+  }
+
+  /**
+   * Send event to multiple specific clients
+   */
+  multicast<T>(
+    clientIds: ClientId[],
+    event: SSEEvent<T>,
+  ): Result<DispatchResult> {
+    try {
+      const connections: Connection[] = [];
+      const notFound: string[] = [];
+
+      for (const clientId of clientIds) {
+        const connection = this.connectionManager.getConnection(clientId);
+        if (connection) {
+          connections.push(connection);
+        } else {
+          notFound.push(clientId);
+        }
+      }
+
+      const result = this.sendToMultipleConnections(connections, event);
+
+      if (result.success && notFound.length > 0) {
+        result.data.errors = [
+          ...(result.data.errors ?? []),
+          `Clients not found: ${notFound.join(", ")}`,
+        ];
+      }
+
+      return result;
+    } catch (error) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          ErrorCode.SEND_FAILED,
+          "Failed to multicast event",
+          error,
+        ),
+      };
+    }
+  }
+
+  /**
+   * Generic send method that routes based on target
+   */
+  send<T>(params: SendParams<T>): Result<DispatchResult> {
+    const { target, targetId, event } = params;
+
+    switch (target) {
+      case "client":
+        if (!targetId) {
+          return {
+            success: false,
+            error: new SSEErrorClass(
+              ErrorCode.VALIDATION_ERROR,
+              "Target ID required for client target",
+            ),
+          };
+        }
+        return this.sendToClient(targetId, event);
+
+      case "user":
+        if (!targetId) {
+          return {
+            success: false,
+            error: new SSEErrorClass(
+              ErrorCode.VALIDATION_ERROR,
+              "Target ID required for user target",
+            ),
+          };
+        }
+        return this.sendToUser(targetId, event);
+
+      case "session":
+        if (!targetId) {
+          return {
+            success: false,
+            error: new SSEErrorClass(
+              ErrorCode.VALIDATION_ERROR,
+              "Target ID required for session target",
+            ),
+          };
+        }
+        return this.sendToSession(targetId, event);
+
+      case "broadcast":
+      case "all":
+        return this.broadcast(event);
+
+      default:
+        return {
+          success: false,
+          error: new SSEErrorClass(
+            ErrorCode.VALIDATION_ERROR,
+            `Invalid target: ${target as string}`,
+          ),
+        };
+    }
+  }
+
+  /**
+   * Format an event as SSE message
+   */
+  formatSSEMessage(event: SSEEvent): string {
+    const lines: string[] = [];
+
+    // Add event ID if provided
+    if (event.id) {
+      lines.push(`id: ${event.id}`);
+    } else {
+      // Generate ID if not provided
+      const id = this.generateEventId();
+      lines.push(`id: ${id}`);
+    }
+
+    // Add retry if provided
+    if (event.retry) {
+      lines.push(`retry: ${event.retry}`);
+    }
+
+    // Add event type
+    lines.push(`event: ${event.type}`);
+
+    // Add timestamp if not provided
+    const data =
+      typeof event.data === "object" && event.data !== null
+        ? {
+            ...(event.data as Record<string, unknown>),
+            timestamp: event.timestamp ?? Date.now(),
+          }
+        : { value: event.data, timestamp: event.timestamp ?? Date.now() };
+
+    // Add data (can be multiple lines)
+    const dataString = JSON.stringify(data);
+    lines.push(`data: ${dataString}`);
+
+    // SSE format requires double newline at the end
+    return lines.join("\n") + "\n\n";
+  }
+
+  /**
+   * Send event to multiple connections
+   */
+  private sendToMultipleConnections<T>(
+    connections: Connection[],
+    event: SSEEvent<T>,
+  ): Result<DispatchResult> {
+    let sentCount = 0;
+    let failedCount = 0;
+    const errors: string[] = [];
+
+    for (const connection of connections) {
+      const success = this.sendEventToConnection(connection, event);
+      if (success) {
+        sentCount++;
+      } else {
+        failedCount++;
+        errors.push(`Failed to send to client ${connection.id}`);
+      }
+    }
+
+    return {
+      success: true,
+      data: {
+        success: failedCount === 0,
+        sentCount,
+        failedCount,
+        errors: errors.length > 0 ? errors : undefined,
+      },
+    };
+  }
+
+  /**
+   * Send event to a single connection
+   */
+  private sendEventToConnection<T>(
+    connection: Connection,
+    event: SSEEvent<T>,
+  ): boolean {
+    try {
+      // Check if connection is still active
+      if (connection.state !== "connected") {
+        console.warn(`Connection ${connection.id} is not in connected state`);
+        return false;
+      }
+
+      // Check if controller is available (might not be set yet if stream hasn't started)
+      if (!connection.controller) {
+        console.warn(`Controller not yet available for ${connection.id}`);
+        return false;
+      }
+
+      // Format the message
+      const message = this.formatSSEMessage(event);
+
+      // Encode and send
+      const encoded = connection.encoder.encode(message);
+
+      // Check if the stream is still writable
+      if (connection.controller.desiredSize === null) {
+        console.warn(`Stream for ${connection.id} is not writable`);
+        return false;
+      }
+
+      // Enqueue the message
+      connection.controller.enqueue(encoded);
+
+      // Update last activity
+      this.connectionManager.updateLastActivity(connection.id);
+
+      return true;
+    } catch (error) {
+      console.error(`Failed to send event to ${connection.id}:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Generate unique event ID
+   */
+  private generateEventId(): string {
+    const timestamp = Date.now();
+    const counter = ++this.eventCounter;
+    return `evt_${timestamp}_${counter}`;
+  }
+}

--- a/src/lib/sse/core/health-monitor.ts
+++ b/src/lib/sse/core/health-monitor.ts
@@ -1,0 +1,373 @@
+/**
+ * Health Monitor
+ *
+ * Manages heartbeat mechanism, client health monitoring, and stale connection cleanup
+ */
+
+import type {
+  ClientId,
+  HealthConfig,
+  HealthStats,
+  HealthStatus,
+  SSEEvent,
+  Result,
+  SSEErrorCode,
+} from "../types";
+import {
+  SSEError as SSEErrorClass,
+  SystemEventType as SystemEvent,
+} from "../types";
+import type { IConnectionManager } from "./connection-manager";
+import type { IEventDispatcher } from "./event-dispatcher";
+
+export interface IHealthMonitor {
+  // Heartbeat management
+  start(): void;
+  stop(): void;
+  sendHeartbeat(): void;
+  handleClientPing(clientId: ClientId): Result<void>;
+
+  // Health checks
+  checkConnectionHealth(clientId: ClientId): HealthStatus;
+  getSystemHealth(): HealthStatus;
+
+  // Statistics
+  getStats(): HealthStats;
+
+  // Cleanup
+  identifyStaleConnections(): ClientId[];
+  cleanupUnhealthyConnections(): number;
+}
+
+export class HealthMonitor implements IHealthMonitor {
+  private heartbeatTimer?: NodeJS.Timeout;
+  private cleanupTimer?: NodeJS.Timeout;
+  private lastPingTimes: Map<ClientId, number>;
+  private stats: HealthStats;
+  private isRunning = false;
+
+  constructor(
+    private readonly config: HealthConfig,
+    private readonly connectionManager: IConnectionManager,
+    private readonly eventDispatcher: IEventDispatcher,
+  ) {
+    this.lastPingTimes = new Map();
+    this.stats = {
+      totalHeartbeatsSent: 0,
+      totalHeartbeatsReceived: 0,
+      clientTimeouts: 0,
+      unhealthyConnections: 0,
+    };
+  }
+
+  /**
+   * Start the health monitoring system
+   */
+  start(): void {
+    if (!this.config.enabled) {
+      console.info("Health monitoring is disabled");
+      return;
+    }
+
+    if (this.isRunning) {
+      console.warn("Health monitor is already running");
+      return;
+    }
+
+    console.info("Starting health monitor", {
+      heartbeatInterval: this.config.heartbeatInterval,
+      clientTimeout: this.config.clientTimeout,
+      cleanupInterval: this.config.cleanupInterval,
+    });
+
+    // Start heartbeat timer
+    this.heartbeatTimer = setInterval(() => {
+      this.sendHeartbeat();
+    }, this.config.heartbeatInterval);
+
+    // Start cleanup timer
+    this.cleanupTimer = setInterval(() => {
+      this.cleanupUnhealthyConnections();
+    }, this.config.cleanupInterval);
+
+    this.isRunning = true;
+  }
+
+  /**
+   * Stop the health monitoring system
+   */
+  stop(): void {
+    if (!this.isRunning) {
+      return;
+    }
+
+    console.info("Stopping health monitor");
+
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = undefined;
+    }
+
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+    }
+
+    this.isRunning = false;
+  }
+
+  /**
+   * Send heartbeat to all connections
+   */
+  sendHeartbeat(): void {
+    const heartbeatEvent: SSEEvent = {
+      type: SystemEvent.HEARTBEAT,
+      data: {
+        timestamp: Date.now(),
+        interval: this.config.heartbeatInterval,
+        nextHeartbeat: Date.now() + this.config.heartbeatInterval,
+      },
+    };
+
+    const result = this.eventDispatcher.broadcast(heartbeatEvent);
+
+    if (result.success) {
+      this.stats.totalHeartbeatsSent += result.data.sentCount;
+      this.stats.lastHeartbeat = new Date();
+
+      console.debug(`Heartbeat sent to ${result.data.sentCount} connections`);
+    } else {
+      console.error("Failed to send heartbeat:", result.error);
+    }
+  }
+
+  /**
+   * Handle ping from client
+   */
+  handleClientPing(clientId: ClientId): Result<void> {
+    const connection = this.connectionManager.getConnection(clientId);
+
+    if (!connection) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          "CLIENT_NOT_FOUND" as SSEErrorCode,
+          `Client ${clientId} not found`,
+        ),
+      };
+    }
+
+    // Update ping time
+    this.lastPingTimes.set(clientId, Date.now());
+    this.stats.totalHeartbeatsReceived++;
+
+    // Update connection activity
+    this.connectionManager.updateLastActivity(clientId);
+
+    // Send pong response
+    const pongEvent: SSEEvent = {
+      type: "system:pong",
+      data: {
+        timestamp: Date.now(),
+        clientId,
+      },
+    };
+
+    this.eventDispatcher.sendToClient(clientId, pongEvent);
+
+    return { success: true, data: undefined };
+  }
+
+  /**
+   * Check health of a specific connection
+   */
+  checkConnectionHealth(clientId: ClientId): HealthStatus {
+    const connection = this.connectionManager.getConnection(clientId);
+
+    if (!connection) {
+      return "unhealthy";
+    }
+
+    if (connection.state !== "connected") {
+      return "unhealthy";
+    }
+
+    const lastActivity = connection.lastActivity.getTime();
+    const now = Date.now();
+    const timeSinceActivity = now - lastActivity;
+
+    // Check if connection is stale
+    if (timeSinceActivity > this.config.clientTimeout) {
+      return "unhealthy";
+    }
+
+    // Check if connection is degraded (approaching timeout)
+    if (timeSinceActivity > this.config.clientTimeout * 0.75) {
+      return "degraded";
+    }
+
+    return "healthy";
+  }
+
+  /**
+   * Get overall system health
+   */
+  getSystemHealth(): HealthStatus {
+    const connections = this.connectionManager.getAllConnections();
+
+    if (connections.size === 0) {
+      return "healthy"; // No connections is not unhealthy
+    }
+
+    let degradedCount = 0;
+    let unhealthyCount = 0;
+
+    for (const [clientId] of connections) {
+      const health = this.checkConnectionHealth(clientId);
+
+      switch (health) {
+        case "degraded":
+          degradedCount++;
+          break;
+        case "unhealthy":
+          unhealthyCount++;
+          break;
+      }
+    }
+
+    const total = connections.size;
+    const unhealthyPercentage = (unhealthyCount / total) * 100;
+    const degradedPercentage = (degradedCount / total) * 100;
+
+    // System is unhealthy if >20% connections are unhealthy
+    if (unhealthyPercentage > 20) {
+      return "unhealthy";
+    }
+
+    // System is degraded if >30% connections are degraded or unhealthy
+    if (degradedPercentage + unhealthyPercentage > 30) {
+      return "degraded";
+    }
+
+    return "healthy";
+  }
+
+  /**
+   * Get health statistics
+   */
+  getStats(): HealthStats {
+    return {
+      ...this.stats,
+      unhealthyConnections: this.identifyStaleConnections().length,
+    };
+  }
+
+  /**
+   * Identify stale connections
+   */
+  identifyStaleConnections(): ClientId[] {
+    const staleConnections: ClientId[] = [];
+    const connections = this.connectionManager.getAllConnections();
+    const now = Date.now();
+
+    for (const [clientId, connection] of connections) {
+      const lastActivity = connection.lastActivity.getTime();
+      const timeSinceActivity = now - lastActivity;
+
+      if (timeSinceActivity > this.config.clientTimeout) {
+        staleConnections.push(clientId);
+      }
+    }
+
+    return staleConnections;
+  }
+
+  /**
+   * Clean up unhealthy connections
+   */
+  cleanupUnhealthyConnections(): number {
+    const staleConnections = this.identifyStaleConnections();
+    let cleanedCount = 0;
+
+    for (const clientId of staleConnections) {
+      const result = this.connectionManager.removeConnection(
+        clientId,
+        "health_check_timeout",
+      );
+
+      if (result.success) {
+        cleanedCount++;
+        this.stats.clientTimeouts++;
+        this.lastPingTimes.delete(clientId);
+
+        console.info(`Removed stale connection: ${clientId}`);
+      }
+    }
+
+    if (cleanedCount > 0) {
+      console.info(`Cleaned up ${cleanedCount} stale connections`);
+    }
+
+    return cleanedCount;
+  }
+
+  /**
+   * Reset statistics
+   */
+  resetStats(): void {
+    this.stats = {
+      totalHeartbeatsSent: 0,
+      totalHeartbeatsReceived: 0,
+      clientTimeouts: 0,
+      unhealthyConnections: 0,
+    };
+    this.lastPingTimes.clear();
+  }
+
+  /**
+   * Get detailed health report
+   */
+  getHealthReport(): {
+    systemHealth: HealthStatus;
+    stats: HealthStats;
+    connectionHealth: Map<ClientId, HealthStatus>;
+    recommendations: string[];
+  } {
+    const systemHealth = this.getSystemHealth();
+    const connectionHealth = new Map<ClientId, HealthStatus>();
+    const recommendations: string[] = [];
+
+    const connections = this.connectionManager.getAllConnections();
+
+    for (const [clientId] of connections) {
+      connectionHealth.set(clientId, this.checkConnectionHealth(clientId));
+    }
+
+    // Generate recommendations
+    if (systemHealth === "unhealthy") {
+      recommendations.push(
+        "System health is critical. Consider increasing timeout values or investigating network issues.",
+      );
+    }
+
+    if (this.stats.clientTimeouts > 10) {
+      recommendations.push(
+        "High number of client timeouts detected. Check client network stability.",
+      );
+    }
+
+    const connectionCount = connections.size;
+    if (connectionCount > 1000) {
+      recommendations.push(
+        "High number of connections. Consider implementing connection pooling or load balancing.",
+      );
+    }
+
+    return {
+      systemHealth,
+      stats: this.getStats(),
+      connectionHealth,
+      recommendations,
+    };
+  }
+}

--- a/src/lib/sse/core/metrics-collector.ts
+++ b/src/lib/sse/core/metrics-collector.ts
@@ -1,0 +1,469 @@
+/**
+ * Metrics Collector
+ *
+ * Collects, aggregates, and reports SSE system metrics
+ */
+
+import type {
+  ClientId,
+  SSEEvent,
+  SSEMetrics,
+  ConnectionStats,
+  EventStats,
+  PerformanceStats,
+  HealthStats,
+} from "../types";
+import type { IConnectionManager } from "./connection-manager";
+import type { IHealthMonitor } from "./health-monitor";
+
+export interface IMetricsCollector {
+  // Recording metrics
+  recordConnection(clientId: ClientId): void;
+  recordDisconnection(clientId: ClientId, duration: number): void;
+  recordEventSent(event: SSEEvent, success: boolean): void;
+  recordEventFailed(event: SSEEvent, error: string): void;
+  recordHeartbeat(clientId: ClientId): void;
+
+  // Retrieving metrics
+  getMetrics(): SSEMetrics;
+  getConnectionStats(): ConnectionStats;
+  getEventStats(): EventStats;
+  getPerformanceStats(): PerformanceStats;
+
+  // Reset
+  reset(): void;
+}
+
+interface EventMetrics {
+  totalSent: number;
+  totalFailed: number;
+  byType: Map<string, number>;
+  lastEventTime?: Date;
+}
+
+interface ConnectionMetrics {
+  totalConnections: number;
+  totalDisconnections: number;
+  totalDuration: number;
+  maxConcurrent: number;
+  connectionTimes: number[];
+}
+
+interface PerformanceMetrics {
+  eventDeliveryTimes: number[];
+  memorySnapshots: number[];
+  startTime: Date;
+}
+
+export class MetricsCollector implements IMetricsCollector {
+  private eventMetrics: EventMetrics;
+  private connectionMetrics: ConnectionMetrics;
+  private performanceMetrics: PerformanceMetrics;
+  private connectionStartTimes: Map<ClientId, number>;
+  private eventRateWindow: number[] = [];
+  private readonly RATE_WINDOW_SIZE = 60; // 60 seconds
+
+  constructor(
+    private readonly connectionManager: IConnectionManager,
+    private readonly healthMonitor?: IHealthMonitor,
+  ) {
+    this.eventMetrics = {
+      totalSent: 0,
+      totalFailed: 0,
+      byType: new Map(),
+    };
+
+    this.connectionMetrics = {
+      totalConnections: 0,
+      totalDisconnections: 0,
+      totalDuration: 0,
+      maxConcurrent: 0,
+      connectionTimes: [],
+    };
+
+    this.performanceMetrics = {
+      eventDeliveryTimes: [],
+      memorySnapshots: [],
+      startTime: new Date(),
+    };
+
+    this.connectionStartTimes = new Map();
+
+    // Start periodic memory snapshots
+    this.startMemoryMonitoring();
+  }
+
+  /**
+   * Record a new connection
+   */
+  recordConnection(clientId: ClientId): void {
+    this.connectionMetrics.totalConnections++;
+    this.connectionStartTimes.set(clientId, Date.now());
+
+    // Update max concurrent connections
+    const currentConnections = this.connectionManager.getConnectionCount();
+    if (currentConnections > this.connectionMetrics.maxConcurrent) {
+      this.connectionMetrics.maxConcurrent = currentConnections;
+    }
+  }
+
+  /**
+   * Record a disconnection
+   */
+  recordDisconnection(clientId: ClientId, duration: number): void {
+    this.connectionMetrics.totalDisconnections++;
+
+    // Calculate connection duration if we have the start time
+    const startTime = this.connectionStartTimes.get(clientId);
+    if (startTime) {
+      const actualDuration = Date.now() - startTime;
+      this.connectionMetrics.totalDuration += actualDuration;
+      this.connectionMetrics.connectionTimes.push(actualDuration);
+
+      // Keep only last 1000 connection times for average calculation
+      if (this.connectionMetrics.connectionTimes.length > 1000) {
+        this.connectionMetrics.connectionTimes.shift();
+      }
+
+      this.connectionStartTimes.delete(clientId);
+    } else {
+      // Use provided duration if we don't have start time
+      this.connectionMetrics.totalDuration += duration;
+    }
+  }
+
+  /**
+   * Record an event being sent
+   */
+  recordEventSent(event: SSEEvent, success: boolean): void {
+    const eventStartTime = Date.now();
+
+    if (success) {
+      this.eventMetrics.totalSent++;
+    } else {
+      this.eventMetrics.totalFailed++;
+    }
+
+    // Track events by type
+    const count = this.eventMetrics.byType.get(event.type) ?? 0;
+    this.eventMetrics.byType.set(event.type, count + 1);
+
+    this.eventMetrics.lastEventTime = new Date();
+
+    // Track event delivery time
+    const deliveryTime = Date.now() - eventStartTime;
+    this.performanceMetrics.eventDeliveryTimes.push(deliveryTime);
+
+    // Keep only last 1000 delivery times
+    if (this.performanceMetrics.eventDeliveryTimes.length > 1000) {
+      this.performanceMetrics.eventDeliveryTimes.shift();
+    }
+
+    // Update event rate
+    this.updateEventRate();
+  }
+
+  /**
+   * Record a failed event
+   */
+  recordEventFailed(event: SSEEvent, error: string): void {
+    this.eventMetrics.totalFailed++;
+    console.error(`Event failed: ${event.type}`, error);
+  }
+
+  /**
+   * Record a heartbeat
+   */
+  recordHeartbeat(): void {
+    // This can be used to track heartbeat-specific metrics
+    const heartbeatType = "system:heartbeat";
+    const count = this.eventMetrics.byType.get(heartbeatType) ?? 0;
+    this.eventMetrics.byType.set(heartbeatType, count + 1);
+  }
+
+  /**
+   * Get all metrics
+   */
+  getMetrics(): SSEMetrics {
+    return {
+      connections: this.getConnectionStats(),
+      events: this.getEventStats(),
+      health: this.getHealthStats(),
+      performance: this.getPerformanceStats(),
+      timestamp: new Date(),
+    };
+  }
+
+  /**
+   * Get connection statistics
+   */
+  getConnectionStats(): ConnectionStats {
+    const connections = this.connectionManager.getAllConnections();
+    const byUser = new Map<string, number>();
+    const bySession = new Map<string, number>();
+
+    // Count connections by user and session
+    for (const [_, connection] of connections) {
+      if (connection.userId) {
+        byUser.set(connection.userId, (byUser.get(connection.userId) ?? 0) + 1);
+      }
+      if (connection.sessionId) {
+        bySession.set(
+          connection.sessionId,
+          (bySession.get(connection.sessionId) ?? 0) + 1,
+        );
+      }
+    }
+
+    // Calculate average duration
+    const averageDuration =
+      this.connectionMetrics.connectionTimes.length > 0
+        ? this.connectionMetrics.connectionTimes.reduce((a, b) => a + b, 0) /
+          this.connectionMetrics.connectionTimes.length
+        : 0;
+
+    return {
+      active: connections.size,
+      total: this.connectionMetrics.totalConnections,
+      byUser,
+      bySession,
+      averageDuration,
+    };
+  }
+
+  /**
+   * Get event statistics
+   */
+  getEventStats(): EventStats {
+    return {
+      sent: this.eventMetrics.totalSent,
+      failed: this.eventMetrics.totalFailed,
+      rate: this.calculateEventRate(),
+      byType: new Map(this.eventMetrics.byType),
+    };
+  }
+
+  /**
+   * Get performance statistics
+   */
+  getPerformanceStats(): PerformanceStats {
+    const avgEventDeliveryMs =
+      this.performanceMetrics.eventDeliveryTimes.length > 0
+        ? this.performanceMetrics.eventDeliveryTimes.reduce(
+            (a, b) => a + b,
+            0,
+          ) / this.performanceMetrics.eventDeliveryTimes.length
+        : 0;
+
+    const currentMemory = process.memoryUsage().heapUsed / 1024 / 1024;
+    const avgMemory =
+      this.performanceMetrics.memorySnapshots.length > 0
+        ? this.performanceMetrics.memorySnapshots.reduce((a, b) => a + b, 0) /
+          this.performanceMetrics.memorySnapshots.length
+        : currentMemory;
+
+    const uptime = Date.now() - this.performanceMetrics.startTime.getTime();
+
+    // Get CPU usage (simplified - in production you might want to use more sophisticated monitoring)
+    const cpuUsage = process.cpuUsage();
+    const cpuPercent =
+      ((cpuUsage.user + cpuUsage.system) / 1000000 / (uptime / 1000)) * 100;
+
+    return {
+      avgEventDeliveryMs,
+      memoryUsageMB: avgMemory,
+      cpuUsage: Math.min(cpuPercent, 100), // Cap at 100%
+      uptime,
+    };
+  }
+
+  /**
+   * Get health statistics
+   */
+  private getHealthStats(): HealthStats {
+    if (this.healthMonitor) {
+      return this.healthMonitor.getStats();
+    }
+
+    // Return default stats if no health monitor
+    return {
+      totalHeartbeatsSent: 0,
+      totalHeartbeatsReceived: 0,
+      clientTimeouts: 0,
+      unhealthyConnections: 0,
+    };
+  }
+
+  /**
+   * Reset all metrics
+   */
+  reset(): void {
+    this.eventMetrics = {
+      totalSent: 0,
+      totalFailed: 0,
+      byType: new Map(),
+    };
+
+    this.connectionMetrics = {
+      totalConnections: 0,
+      totalDisconnections: 0,
+      totalDuration: 0,
+      maxConcurrent: 0,
+      connectionTimes: [],
+    };
+
+    this.performanceMetrics = {
+      eventDeliveryTimes: [],
+      memorySnapshots: [],
+      startTime: new Date(),
+    };
+
+    this.connectionStartTimes.clear();
+    this.eventRateWindow = [];
+  }
+
+  /**
+   * Update event rate tracking
+   */
+  private updateEventRate(): void {
+    const now = Date.now();
+    this.eventRateWindow.push(now);
+
+    // Remove events older than window size
+    const cutoff = now - this.RATE_WINDOW_SIZE * 1000;
+    this.eventRateWindow = this.eventRateWindow.filter((time) => time > cutoff);
+  }
+
+  /**
+   * Calculate current event rate
+   */
+  private calculateEventRate(): number {
+    const now = Date.now();
+    const cutoff = now - this.RATE_WINDOW_SIZE * 1000;
+    const recentEvents = this.eventRateWindow.filter((time) => time > cutoff);
+
+    // Return events per second
+    return recentEvents.length / this.RATE_WINDOW_SIZE;
+  }
+
+  /**
+   * Start periodic memory monitoring
+   */
+  private startMemoryMonitoring(): void {
+    setInterval(() => {
+      const memoryMB = process.memoryUsage().heapUsed / 1024 / 1024;
+      this.performanceMetrics.memorySnapshots.push(memoryMB);
+
+      // Keep only last 60 snapshots (1 hour if taken every minute)
+      if (this.performanceMetrics.memorySnapshots.length > 60) {
+        this.performanceMetrics.memorySnapshots.shift();
+      }
+    }, 60000); // Every minute
+  }
+
+  /**
+   * Get detailed metrics report
+   */
+  getDetailedReport(): {
+    summary: SSEMetrics;
+    analysis: {
+      connectionHealth: string;
+      eventThroughput: string;
+      performanceStatus: string;
+      recommendations: string[];
+    };
+  } {
+    const metrics = this.getMetrics();
+    const analysis = {
+      connectionHealth: this.analyzeConnectionHealth(metrics.connections),
+      eventThroughput: this.analyzeEventThroughput(metrics.events),
+      performanceStatus: this.analyzePerformance(metrics.performance),
+      recommendations: this.generateRecommendations(metrics),
+    };
+
+    return {
+      summary: metrics,
+      analysis,
+    };
+  }
+
+  /**
+   * Analyze connection health
+   */
+  private analyzeConnectionHealth(stats: ConnectionStats): string {
+    if (stats.active === 0) {
+      return "No active connections";
+    }
+
+    const utilizationPercent = (stats.active / 10000) * 100; // Assuming max 10k connections
+
+    if (utilizationPercent > 80) {
+      return "Critical: Near maximum capacity";
+    } else if (utilizationPercent > 60) {
+      return "Warning: High connection load";
+    } else {
+      return "Healthy: Normal connection load";
+    }
+  }
+
+  /**
+   * Analyze event throughput
+   */
+  private analyzeEventThroughput(stats: EventStats): string {
+    const failureRate = stats.sent > 0 ? (stats.failed / stats.sent) * 100 : 0;
+
+    if (failureRate > 10) {
+      return "Critical: High failure rate";
+    } else if (failureRate > 5) {
+      return "Warning: Elevated failure rate";
+    } else if (stats.rate > 100) {
+      return "Warning: Very high event rate";
+    } else {
+      return "Healthy: Normal event throughput";
+    }
+  }
+
+  /**
+   * Analyze performance
+   */
+  private analyzePerformance(stats: PerformanceStats): string {
+    if (stats.memoryUsageMB > 512) {
+      return "Critical: High memory usage";
+    } else if (stats.cpuUsage > 80) {
+      return "Critical: High CPU usage";
+    } else if (stats.avgEventDeliveryMs > 100) {
+      return "Warning: Slow event delivery";
+    } else {
+      return "Healthy: Good performance";
+    }
+  }
+
+  /**
+   * Generate recommendations
+   */
+  private generateRecommendations(metrics: SSEMetrics): string[] {
+    const recommendations: string[] = [];
+
+    if (metrics.connections.active > 5000) {
+      recommendations.push(
+        "Consider implementing connection pooling or load balancing",
+      );
+    }
+
+    if (metrics.events.failed > metrics.events.sent * 0.05) {
+      recommendations.push("Investigate high event failure rate");
+    }
+
+    if (metrics.performance.memoryUsageMB > 256) {
+      recommendations.push("Monitor memory usage and consider optimization");
+    }
+
+    if (metrics.performance.avgEventDeliveryMs > 50) {
+      recommendations.push(
+        "Optimize event delivery pipeline for better latency",
+      );
+    }
+
+    return recommendations;
+  }
+}

--- a/src/lib/sse/index.ts
+++ b/src/lib/sse/index.ts
@@ -1,0 +1,75 @@
+/**
+ * SSE Library Main Export
+ * 
+ * Centralized exports for the Server-Sent Events system
+ */
+
+// Main service
+export { SSEService, getSSEService } from './services/sse-service';
+export type { ISSEService } from './services/sse-service';
+
+// Core components (for advanced usage)
+export { ConnectionManager } from './core/connection-manager';
+export { EventDispatcher } from './core/event-dispatcher';
+export { HealthMonitor } from './core/health-monitor';
+export { MetricsCollector } from './core/metrics-collector';
+
+// Types and interfaces
+export type {
+  // Connection types
+  ClientId,
+  UserId,
+  SessionId,
+  Connection,
+  ConnectionOptions,
+  ConnectionResult,
+  ConnectionState,
+  
+  // Event types
+  SSEEvent,
+  EventTarget,
+  PrioritizedEvent,
+  SendParams,
+  DispatchResult,
+  
+  // Health types
+  HealthStatus,
+  HealthConfig,
+  HealthStats,
+  
+  // Metrics types
+  SSEMetrics,
+  ConnectionStats,
+  EventStats,
+  PerformanceStats,
+  
+  // Configuration
+  SSEConfig,
+  RateLimitConfig,
+  LoggingConfig,
+  
+  // Error handling
+  Result,
+  
+  // API types
+  SendEventRequest,
+  SendEventResponse,
+  StatsResponse
+} from './types';
+
+// Export enums and constants
+export {
+  EventPriority,
+  SystemEventType,
+  SSEErrorCode,
+  DEFAULT_CONFIG,
+  SSEError
+} from './types';
+
+// Convenience re-exports for common use cases
+import { SSEService } from './services/sse-service';
+import type { SSEConfig } from './types';
+
+export const createSSEService = (config?: Partial<SSEConfig>) => {
+  return new SSEService(config);
+};

--- a/src/lib/sse/services/sse-service.ts
+++ b/src/lib/sse/services/sse-service.ts
@@ -1,0 +1,433 @@
+/**
+ * SSE Service
+ *
+ * Main facade for the Server-Sent Events system
+ * Coordinates all components and provides a unified API
+ */
+
+import type {
+  ConnectionOptions,
+  ConnectionResult,
+  ClientId,
+  SSEEvent,
+  SendParams,
+  DispatchResult,
+  SSEMetrics,
+  HealthStatus,
+  SSEConfig,
+  Result,
+  SSEErrorCode,
+  EventTarget,
+} from "../types";
+import {
+  DEFAULT_CONFIG,
+  SSEError as SSEErrorClass,
+  SystemEventType as SystemEvent,
+} from "../types";
+import { ConnectionManager } from "../core/connection-manager";
+import { EventDispatcher } from "../core/event-dispatcher";
+import { HealthMonitor } from "../core/health-monitor";
+import { MetricsCollector } from "../core/metrics-collector";
+
+export interface ISSEService {
+  // Connection Management
+  createConnection(options: ConnectionOptions): Result<ConnectionResult>;
+  closeConnection(clientId: ClientId, reason?: string): Result<void>;
+  getConnection(clientId: ClientId): boolean;
+
+  // Event Operations
+  send<T>(params: SendParams<T>): Result<DispatchResult>;
+  sendToClient<T>(
+    clientId: ClientId,
+    event: SSEEvent<T>,
+  ): Result<DispatchResult>;
+  sendToUser<T>(userId: string, event: SSEEvent<T>): Result<DispatchResult>;
+  sendToSession<T>(
+    sessionId: string,
+    event: SSEEvent<T>,
+  ): Result<DispatchResult>;
+  broadcast<T>(event: SSEEvent<T>): Result<DispatchResult>;
+
+  // Monitoring
+  getMetrics(): SSEMetrics;
+  getHealth(): HealthStatus;
+
+  // Lifecycle
+  initialize(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
+export class SSEService implements ISSEService {
+  private readonly config: SSEConfig;
+  private readonly connectionManager: ConnectionManager;
+  private readonly eventDispatcher: EventDispatcher;
+  private readonly healthMonitor: HealthMonitor;
+  private readonly metricsCollector: MetricsCollector;
+  private isInitialized = false;
+  private isShuttingDown = false;
+
+  constructor(config: Partial<SSEConfig> = {}) {
+    // Merge with default config
+    this.config = { ...DEFAULT_CONFIG, ...config };
+
+    // Initialize core components
+    this.connectionManager = new ConnectionManager(this.config.maxConnections);
+    this.eventDispatcher = new EventDispatcher(this.connectionManager);
+    this.healthMonitor = new HealthMonitor(
+      this.config.health,
+      this.connectionManager,
+      this.eventDispatcher,
+    );
+    this.metricsCollector = new MetricsCollector(
+      this.connectionManager,
+      this.healthMonitor,
+    );
+
+    console.info("SSE Service created", {
+      maxConnections: this.config.maxConnections,
+      healthEnabled: this.config.health.enabled,
+      rateLimitEnabled: this.config.rateLimit.enabled,
+    });
+  }
+
+  /**
+   * Initialize the SSE service
+   */
+  async initialize(): Promise<void> {
+    if (this.isInitialized) {
+      console.warn("SSE Service is already initialized");
+      return;
+    }
+
+    console.info("Initializing SSE Service...");
+
+    // Start health monitoring
+    if (this.config.health.enabled) {
+      this.healthMonitor.start();
+    }
+
+    // Setup graceful shutdown handlers
+    this.setupShutdownHandlers();
+
+    this.isInitialized = true;
+    console.info("SSE Service initialized successfully");
+  }
+
+  /**
+   * Create a new SSE connection
+   */
+  createConnection(options: ConnectionOptions = {}): Result<ConnectionResult> {
+    if (this.isShuttingDown) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          "INTERNAL_ERROR" as SSEErrorCode,
+          "Service is shutting down",
+        ),
+      };
+    }
+
+    if (!this.isInitialized) {
+      console.warn("SSE Service not initialized, initializing now...");
+      this.initialize().catch(console.error);
+    }
+
+    // Create the connection
+    const result = this.connectionManager.createConnection(options);
+
+    if (result.success) {
+      // Record metrics
+      this.metricsCollector.recordConnection(result.data.clientId);
+
+      // Log connection
+      console.info("SSE connection created", {
+        clientId: result.data.clientId,
+        userId: options.userId,
+        sessionId: options.sessionId,
+        activeConnections: this.connectionManager.getConnectionCount(),
+        userCount: this.connectionManager.getUserCount(),
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Close an SSE connection
+   */
+  closeConnection(clientId: ClientId, reason = "manual"): Result<void> {
+    // Send goodbye message before closing
+    const goodbyeEvent: SSEEvent = {
+      type: SystemEvent.CONNECTION_CLOSED,
+      data: {
+        reason,
+        timestamp: Date.now(),
+      },
+    };
+
+    this.eventDispatcher.sendToClient(clientId, goodbyeEvent);
+
+    // Get connection duration for metrics
+    const connection = this.connectionManager.getConnection(clientId);
+    const duration = connection
+      ? Date.now() - connection.connectedAt.getTime()
+      : 0;
+
+    // Remove the connection
+    const result = this.connectionManager.removeConnection(clientId, reason);
+
+    if (result.success) {
+      // Record metrics
+      this.metricsCollector.recordDisconnection(clientId, duration);
+
+      console.info("SSE connection closed", {
+        clientId,
+        reason,
+        duration,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Check if a connection exists
+   */
+  getConnection(clientId: ClientId): boolean {
+    return this.connectionManager.hasConnection(clientId);
+  }
+
+  /**
+   * Send event using generic parameters
+   */
+  send<T>(params: SendParams<T>): Result<DispatchResult> {
+    if (this.isShuttingDown) {
+      return {
+        success: false,
+        error: new SSEErrorClass(
+          "INTERNAL_ERROR" as SSEErrorCode,
+          "Service is shutting down",
+        ),
+      };
+    }
+
+    const result = this.eventDispatcher.send(params);
+
+    // Record metrics
+    if (result.success) {
+      this.metricsCollector.recordEventSent(params.event, result.data.success);
+    } else {
+      this.metricsCollector.recordEventFailed(
+        params.event,
+        result.error.message,
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Send event to specific client
+   */
+  sendToClient<T>(
+    clientId: ClientId,
+    event: SSEEvent<T>,
+  ): Result<DispatchResult> {
+    return this.send({
+      target: "client" as EventTarget,
+      targetId: clientId,
+      event,
+    });
+  }
+
+  /**
+   * Send event to all connections of a user
+   */
+  sendToUser<T>(userId: string, event: SSEEvent<T>): Result<DispatchResult> {
+    return this.send({
+      target: "user" as EventTarget,
+      targetId: userId,
+      event,
+    });
+  }
+
+  /**
+   * Send event to all connections in a session
+   */
+  sendToSession<T>(
+    sessionId: string,
+    event: SSEEvent<T>,
+  ): Result<DispatchResult> {
+    return this.send({
+      target: "session" as EventTarget,
+      targetId: sessionId,
+      event,
+    });
+  }
+
+  /**
+   * Broadcast event to all connections
+   */
+  broadcast<T>(event: SSEEvent<T>): Result<DispatchResult> {
+    return this.send({
+      target: "broadcast" as EventTarget,
+      event,
+    });
+  }
+
+  /**
+   * Get system metrics
+   */
+  getMetrics(): SSEMetrics {
+    return this.metricsCollector.getMetrics();
+  }
+
+  /**
+   * Get system health status
+   */
+  getHealth(): HealthStatus {
+    return this.healthMonitor.getSystemHealth();
+  }
+
+  /**
+   * Get detailed status report
+   */
+  getStatus(): {
+    initialized: boolean;
+    shuttingDown: boolean;
+    health: HealthStatus;
+    metrics: SSEMetrics;
+    config: SSEConfig;
+  } {
+    return {
+      initialized: this.isInitialized,
+      shuttingDown: this.isShuttingDown,
+      health: this.getHealth(),
+      metrics: this.getMetrics(),
+      config: this.config,
+    };
+  }
+
+  /**
+   * Handle client ping (for heartbeat)
+   */
+  handlePing(clientId: ClientId): Result<void> {
+    return this.healthMonitor.handleClientPing(clientId);
+  }
+
+  /**
+   * Gracefully shutdown the service
+   */
+  async shutdown(): Promise<void> {
+    if (this.isShuttingDown) {
+      console.warn("SSE Service is already shutting down");
+      return;
+    }
+
+    this.isShuttingDown = true;
+    console.info("Starting SSE Service shutdown...");
+
+    // Stop health monitoring
+    this.healthMonitor.stop();
+
+    // Send shutdown notification to all clients
+    const shutdownEvent: SSEEvent = {
+      type: SystemEvent.SERVER_SHUTDOWN,
+      data: {
+        message: "Server is shutting down",
+        timestamp: Date.now(),
+      },
+    };
+
+    this.broadcast(shutdownEvent);
+
+    // Wait a bit for events to be sent
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Close all connections
+    const connections = this.connectionManager.getAllConnections();
+    for (const [clientId] of connections) {
+      this.closeConnection(clientId, "server_shutdown");
+    }
+
+    console.info("SSE Service shutdown complete", {
+      closedConnections: connections.size,
+    });
+  }
+
+  /**
+   * Setup graceful shutdown handlers
+   */
+  private setupShutdownHandlers(): void {
+    const shutdownHandler = async (signal: string): Promise<void> => {
+      console.info(`Received ${signal}, initiating graceful shutdown...`);
+      await this.shutdown();
+      process.exit(0);
+    };
+
+    // Handle different shutdown signals
+    process.once("SIGTERM", () => {
+      void shutdownHandler("SIGTERM");
+    });
+    process.once("SIGINT", () => {
+      void shutdownHandler("SIGINT");
+    });
+    process.once("SIGUSR2", () => {
+      void shutdownHandler("SIGUSR2");
+    }); // For nodemon
+  }
+
+  /**
+   * Get connection count
+   */
+  getConnectionCount(): number {
+    return this.connectionManager.getConnectionCount();
+  }
+
+  /**
+   * Get active connections for a user
+   */
+  getUserConnectionCount(userId: string): number {
+    return this.connectionManager.getConnectionsByUser(userId).length;
+  }
+
+  /**
+   * Get active connections for a session
+   */
+  getSessionConnectionCount(sessionId: string): number {
+    return this.connectionManager.getConnectionsBySession(sessionId).length;
+  }
+
+  /**
+   * Clean up stale connections manually
+   */
+  cleanupStaleConnections(): number {
+    return this.healthMonitor.cleanupUnhealthyConnections();
+  }
+
+  /**
+   * Get detailed report
+   */
+  getDetailedReport(): {
+    status: ReturnType<SSEService["getStatus"]>;
+    health: ReturnType<HealthMonitor["getHealthReport"]>;
+    metrics: ReturnType<MetricsCollector["getDetailedReport"]>;
+  } {
+    return {
+      status: this.getStatus(),
+      health: this.healthMonitor.getHealthReport(),
+      metrics: this.metricsCollector.getDetailedReport(),
+    };
+  }
+}
+
+// Export singleton instance for convenience
+let sseServiceInstance: SSEService | null = null;
+
+export function getSSEService(config?: Partial<SSEConfig>): SSEService {
+  sseServiceInstance ??= new SSEService(config);
+  return sseServiceInstance;
+}
+
+// Also export for direct instantiation
+export default SSEService;

--- a/src/lib/sse/types/index.ts
+++ b/src/lib/sse/types/index.ts
@@ -1,0 +1,351 @@
+/**
+ * SSE System Type Definitions
+ *
+ * Core types and interfaces for the Server-Sent Events system
+ */
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+/**
+ * Unique identifier for SSE connections
+ */
+export type ClientId = string;
+export type UserId = string;
+export type SessionId = string;
+
+/**
+ * Connection state machine states
+ */
+export type ConnectionState =
+  | "connecting"
+  | "connected"
+  | "disconnecting"
+  | "disconnected";
+
+/**
+ * System health status
+ */
+export type HealthStatus = "healthy" | "degraded" | "unhealthy";
+
+/**
+ * Event priority levels for queue management
+ */
+export enum EventPriority {
+  CRITICAL = 0, // System events, errors
+  HIGH = 1, // Important notifications
+  NORMAL = 2, // Regular updates
+  LOW = 3, // Background updates
+}
+
+// ============================================================================
+// Connection Interfaces
+// ============================================================================
+
+/**
+ * Options for creating a new SSE connection
+ */
+export interface ConnectionOptions {
+  userId?: UserId;
+  sessionId?: SessionId;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Represents an active SSE connection
+ */
+export interface Connection {
+  id: ClientId;
+  userId?: UserId;
+  sessionId?: SessionId;
+  connectedAt: Date;
+  lastActivity: Date;
+  state: ConnectionState;
+  metadata?: Record<string, unknown>;
+  controller: ReadableStreamDefaultController<Uint8Array> | null;
+  encoder: TextEncoder;
+}
+
+/**
+ * Result of creating a new connection
+ */
+export interface ConnectionResult {
+  clientId: ClientId;
+  stream: ReadableStream<Uint8Array>;
+}
+
+// ============================================================================
+// Event Interfaces
+// ============================================================================
+
+/**
+ * Base SSE event structure
+ */
+export interface SSEEvent<T = unknown> {
+  id?: string;
+  type: string;
+  data: T;
+  retry?: number;
+  timestamp?: number;
+}
+
+/**
+ * System event types
+ */
+export enum SystemEventType {
+  CONNECTION_ESTABLISHED = "system:connection:established",
+  CONNECTION_CLOSED = "system:connection:closed",
+  HEARTBEAT = "system:heartbeat",
+  SERVER_SHUTDOWN = "system:shutdown",
+  ERROR = "system:error",
+}
+
+/**
+ * Event with priority for queue management
+ */
+export interface PrioritizedEvent<T = unknown> extends SSEEvent<T> {
+  priority: EventPriority;
+  expiresAt?: Date;
+}
+
+/**
+ * Event dispatch target types
+ */
+export type EventTarget = "client" | "user" | "session" | "broadcast" | "all";
+
+/**
+ * Parameters for sending events
+ */
+export interface SendParams<T = unknown> {
+  target: EventTarget;
+  targetId?: string;
+  event: SSEEvent<T>;
+}
+
+/**
+ * Result of event dispatch operation
+ */
+export interface DispatchResult {
+  success: boolean;
+  sentCount: number;
+  failedCount: number;
+  errors?: string[];
+}
+
+// ============================================================================
+// Health & Monitoring Interfaces
+// ============================================================================
+
+/**
+ * Configuration for health monitoring
+ */
+export interface HealthConfig {
+  enabled: boolean;
+  heartbeatInterval: number; // milliseconds
+  clientTimeout: number; // milliseconds
+  cleanupInterval: number; // milliseconds
+}
+
+/**
+ * Health statistics
+ */
+export interface HealthStats {
+  totalHeartbeatsSent: number;
+  totalHeartbeatsReceived: number;
+  clientTimeouts: number;
+  lastHeartbeat?: Date;
+  unhealthyConnections: number;
+}
+
+// ============================================================================
+// Metrics Interfaces
+// ============================================================================
+
+/**
+ * Connection statistics
+ */
+export interface ConnectionStats {
+  active: number;
+  total: number;
+  byUser: Map<UserId, number>;
+  bySession: Map<SessionId, number>;
+  averageDuration: number;
+}
+
+/**
+ * Event statistics
+ */
+export interface EventStats {
+  sent: number;
+  failed: number;
+  rate: number; // events per second
+  byType: Map<string, number>;
+}
+
+/**
+ * Performance statistics
+ */
+export interface PerformanceStats {
+  avgEventDeliveryMs: number;
+  memoryUsageMB: number;
+  cpuUsage: number;
+  uptime: number;
+}
+
+/**
+ * Complete SSE metrics
+ */
+export interface SSEMetrics {
+  connections: ConnectionStats;
+  events: EventStats;
+  health: HealthStats;
+  performance: PerformanceStats;
+  timestamp: Date;
+}
+
+// ============================================================================
+// Configuration Interfaces
+// ============================================================================
+
+/**
+ * Rate limiting configuration
+ */
+export interface RateLimitConfig {
+  enabled: boolean;
+  windowMs: number;
+  maxRequests: number;
+}
+
+/**
+ * Logging configuration
+ */
+export interface LoggingConfig {
+  level: "debug" | "info" | "warn" | "error";
+  maxLogs: number;
+  enableConsole: boolean;
+}
+
+/**
+ * Complete SSE configuration
+ */
+export interface SSEConfig {
+  maxConnections: number;
+  connectionTimeout: number;
+  health: HealthConfig;
+  rateLimit: RateLimitConfig;
+  logging: LoggingConfig;
+  metrics: {
+    enabled: boolean;
+    interval: number;
+  };
+}
+
+/**
+ * Default configuration values
+ */
+export const DEFAULT_CONFIG: SSEConfig = {
+  maxConnections: 10000,
+  connectionTimeout: 120000, // 2 minutes
+  health: {
+    enabled: true,
+    heartbeatInterval: 30000, // 30 seconds
+    clientTimeout: 60000, // 60 seconds
+    cleanupInterval: 60000, // 60 seconds
+  },
+  rateLimit: {
+    enabled: true,
+    windowMs: 60000, // 1 minute
+    maxRequests: 100,
+  },
+  logging: {
+    level: "info",
+    maxLogs: 1000,
+    enableConsole: true,
+  },
+  metrics: {
+    enabled: true,
+    interval: 60000, // 1 minute
+  },
+};
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+/**
+ * SSE error codes
+ */
+export enum SSEErrorCode {
+  CONNECTION_FAILED = "CONNECTION_FAILED",
+  CLIENT_NOT_FOUND = "CLIENT_NOT_FOUND",
+  SEND_FAILED = "SEND_FAILED",
+  VALIDATION_ERROR = "VALIDATION_ERROR",
+  RATE_LIMIT_EXCEEDED = "RATE_LIMIT_EXCEEDED",
+  MAX_CONNECTIONS_REACHED = "MAX_CONNECTIONS_REACHED",
+  INTERNAL_ERROR = "INTERNAL_ERROR",
+}
+
+/**
+ * Base SSE error class
+ */
+export class SSEError extends Error {
+  constructor(
+    public readonly code: SSEErrorCode,
+    message: string,
+    public readonly details?: unknown,
+    public readonly recoverable = true,
+  ) {
+    super(message);
+    this.name = "SSEError";
+  }
+}
+
+// ============================================================================
+// Result Type for Error Handling
+// ============================================================================
+
+/**
+ * Result type for consistent error handling
+ */
+export type Result<T, E = SSEError> =
+  | { success: true; data: T }
+  | { success: false; error: E };
+
+// ============================================================================
+// API Types
+// ============================================================================
+
+/**
+ * Request body for sending events via API
+ */
+export interface SendEventRequest {
+  target: EventTarget;
+  targetId?: string;
+  event: {
+    type: string;
+    data: unknown;
+    id?: string;
+    retry?: number;
+  };
+}
+
+/**
+ * Response from send event API
+ */
+export interface SendEventResponse {
+  success: boolean;
+  sentCount: number;
+  failedCount: number;
+  errors?: string[];
+  stats?: SSEMetrics;
+}
+
+/**
+ * Response from stats API
+ */
+export interface StatsResponse {
+  metrics: SSEMetrics;
+  health: HealthStatus;
+  uptime: number;
+}

--- a/src/types/sse.ts
+++ b/src/types/sse.ts
@@ -1,0 +1,62 @@
+/**
+ * SSE Type Definitions
+ *
+ * Centralized type definitions for Server-Sent Events functionality
+ */
+
+// Re-export types from hook
+export type {
+  SSEEvent,
+  SSEMetrics,
+  SSEHealth,
+  ConnectionOptions,
+  SendEventParams,
+  SendEventResult,
+  UseSSEConnectionReturn,
+} from "@/hooks/useSSEConnection";
+
+// Re-export types from SSE library
+export type {
+  ClientId,
+  UserId,
+  SessionId,
+  ConnectionState,
+  Connection,
+  SSEEvent as LibSSEEvent,
+  EventTarget,
+  SendParams,
+  DispatchResult,
+  SSEMetrics as LibSSEMetrics,
+  HealthStatus,
+  SSEConfig,
+  Result,
+  SSEError,
+  SSEErrorCode,
+} from "@/lib/sse/types";
+
+// Import types for use in this file
+import type { SSEEvent, SSEHealth } from "@/hooks/useSSEConnection";
+
+// Additional type utilities
+export type EventData<T = unknown> = T;
+
+export interface SSEMessage<T = unknown> {
+  id?: string;
+  event?: string;
+  data: T;
+  retry?: number;
+}
+
+export type EventHandler<T = unknown> = (event: SSEEvent<T>) => void;
+
+export interface SSEConnectionState {
+  connected: boolean;
+  connecting: boolean;
+  error: string | null;
+  health: SSEHealth;
+}
+
+export interface SSEEventLogEntry<T = unknown> extends SSEEvent<T> {
+  receivedAt: number;
+  processed: boolean;
+}


### PR DESCRIPTION
Implements a complete Server-Sent Events system for real-time server-to-client communication with support for targeted messaging, automatic reconnection, and comprehensive monitoring.

  What Was Built

  Core SSE System (/src/lib/sse/)

  - Connection Manager: Manages client connections with automatic cleanup and reconnection support
  - Event Dispatcher: Sends targeted events to specific clients, users, sessions, or broadcast to all
  - Health Monitor: Tracks connection health with 30-second heartbeat intervals
  - Metrics Collector: Gathers statistics on active connections, events, and data throughput

  API Endpoints (/src/app/api/sse/)

  - GET /api/sse/stream - SSE streaming endpoint for client connections
  - POST /api/sse/send - Send events with targeting options
  - GET /api/sse/stats - Real-time system statistics

  React Integration

  - useSSEConnection hook for managing SSE connections in React components
  - Automatic reconnection with exponential backoff
  - Event handling with TypeScript support
  - Real-time metrics and health status

  Testing Dashboard (/src/app/(public)/sse/)

  Interactive dashboard featuring:
  - Connection controls with custom user/session IDs
  - Live connection status and health monitoring
  - Event sender with targeting options (broadcast, user, session, client)
  - Real-time event log
  - Metrics panel showing connection statistics
  - Pre-built event templates for quick testing

  Key Features

  - Targeted Messaging: Send events to all clients, specific users, sessions, or individual connections
  - Automatic Reconnection: Client-side reconnection with exponential backoff
  - Real-time Monitoring: Live metrics and health status tracking
  - Type Safety: Full TypeScript implementation with Zod validation
  - Event History: Track and display all received events in the dashboard

Demo:


https://github.com/user-attachments/assets/a18e155d-b8e0-440b-a4d5-2d994078d2b5

