### PR TITLE
feat: SSE implementation for real-time event streaming with logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ tolgee.config.yaml
 
 # editor directories
 .vscode
+
+logs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Nomey Web App
+
 This is the official repository for the Nomey web app, built on the T3 Stack with custom extensions.
 
 ## Tech Stack
@@ -12,7 +13,7 @@ This is the official repository for the Nomey web app, built on the T3 Stack wit
 - [tolgee](https://tolgee.io/) - Translation Management
 - [Meilisearch](https://www.meilisearch.com/) - Full-text search
 - [Upstash](https://upstash.com/) Next compatible redis
-- [Qstash](https://upstash.com/docs/qstash) Next compatible queue handling 
+- [Qstash](https://upstash.com/docs/qstash) Next compatible queue handling
 - [Vitest](https://vitest.dev/) - Testing Framework
 
 ## Testing
@@ -42,6 +43,7 @@ npm run test
 ## Local Development
 
 ### Clone and Install
+
 ```bash
 git clone git@github.com:nomeyy/nomey-next.git
 cd nomey-next
@@ -62,7 +64,7 @@ npm run dev
 
 ## Learn More
 
- - [Nomey Documentation (WIP)](https://nomey.mintlify.app/)
- - [Next Documentation](https://nextjs.org/docs)
- - [T3 Stack Documentation](https://create.t3.gg/en/usage/first-steps)
- - [Mux Documentation](https://www.mux.com/docs)
+- [Nomey Documentation (WIP)](https://nomey.mintlify.app/)
+- [Next Documentation](https://nextjs.org/docs)
+- [T3 Stack Documentation](https://create.t3.gg/en/usage/first-steps)
+- [Mux Documentation](https://www.mux.com/docs)

--- a/src/app/(protected)/broadcast-panel/page.tsx
+++ b/src/app/(protected)/broadcast-panel/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function BroadcastPanel() {
+  const [eventName, setEventName] = useState("");
+  const [payload, setPayload] = useState("");
+
+  const [mainOption, setMainOption] = useState("Broadcast");
+  const [users, setUsers] = useState([]);
+  const [selectedUserId, setSelectedUserId] = useState("");
+
+  const sendEvent = async () => {
+    await fetch("/api/sse/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        targetId: mainOption === "Broadcast" ? null : selectedUserId,
+        eventName: mainOption === "Broadcast" ? "broadcast" : eventName,
+        payload: payload || "{}",
+      }),
+    });
+
+    setEventName("");
+    setPayload("");
+    setMainOption("Broadcast");
+    setSelectedUserId("");
+  };
+
+  const fetchUsers = async () => {
+    const res = await fetch("/api/users", { method: "GET" });
+    setUsers(await res.json());
+  };
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  return (
+    <div className="w-100 p-4">
+      <h1 className="mb-4 text-xl font-bold">Stream New Event</h1>
+
+      <select
+        id="event-select"
+        value={mainOption}
+        onChange={(e) => setMainOption(e.target.value)}
+        className="mb-2 w-full rounded-sm border bg-white p-2 text-black"
+      >
+        <option value="Broadcast" className="bg-white text-black">
+          Broadcast
+        </option>
+        <option value="User" className="bg-white text-black">
+          User
+        </option>
+      </select>
+
+      {mainOption === "User" && (
+        <select
+          id="user-select"
+          value={selectedUserId}
+          onChange={(e) => setSelectedUserId(e.target.value)}
+          className="mb-2 w-full rounded-sm border bg-white p-2 text-black"
+        >
+          <option value="" className="bg-white text-black">
+            Select a User
+          </option>
+          {users.map((user: any) => (
+            <option
+              key={user.id}
+              value={user.id}
+              className="bg-white text-black"
+            >
+              {user.name || "Unnamed User"} -{" "}
+              {user.is_connected ? "Online" : "Offline"}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {mainOption !== "Broadcast" && (
+        <input
+          id="event-name"
+          type="text"
+          placeholder="Event Name"
+          value={eventName}
+          onChange={(e) => setEventName(e.target.value)}
+          className="mb-2 w-full rounded-sm border p-2"
+        />
+      )}
+
+      <textarea
+        id="payload"
+        placeholder="Type your message here..."
+        value={payload}
+        onChange={(e) => setPayload(e.target.value)}
+        className="mb-2 w-full rounded-sm border p-2"
+        rows={4}
+      />
+
+      <button
+        onClick={sendEvent}
+        className="mb-4 w-full cursor-pointer rounded bg-green-600 px-3 py-2 text-white"
+      >
+        Send
+      </button>
+    </div>
+  );
+}

--- a/src/app/(protected)/subscriber-panel/page.tsx
+++ b/src/app/(protected)/subscriber-panel/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useState, useCallback } from "react";
+
+import { useSSEControl } from "@/hooks/useSSEControl";
+
+export default function SubscriberPanel() {
+  const [messages, setMessages] = useState<any[]>([]);
+
+  const handleEvent = useCallback((data: any, event: MessageEvent) => {
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        event: data?.event || "custom",
+        data: data?.payload,
+        timestamp: new Date().toLocaleTimeString(),
+      },
+    ]);
+  }, []);
+
+  const { connect, disconnect, connected } = useSSEControl(
+    ["message", "ping", "broadcast"],
+    handleEvent,
+  );
+
+  const handleDisconnect = useCallback(() => {
+    disconnect();
+    setMessages([]);
+  }, [disconnect]);
+
+  return (
+    <div className="flex flex-col items-center justify-center p-6">
+      <h1 className="mb-4 text-xl font-semibold">Live SSE Notifications</h1>
+
+      {!connected ? (
+        <button
+          onClick={connect}
+          className="transition-colorsf mb-4 cursor-pointer rounded bg-green-600 px-3 py-2 text-white hover:bg-green-700"
+        >
+          Connect
+        </button>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div className="max-h-[500px] min-w-[300px] overflow-y-auto rounded-lg bg-gray-100 p-4 shadow">
+            {messages.length === 0 && (
+              <p className="text-gray-500">No notifications received yet...</p>
+            )}
+            <ul className="space-y-3">
+              {messages.map((message) => (
+                <li
+                  key={message.id}
+                  className="rounded border border-gray-200 bg-white p-3 text-center shadow-sm"
+                >
+                  <div className="text-sm text-gray-600">
+                    <strong>{message.event}</strong> - {message.timestamp}
+                  </div>
+                  <pre className="mt-1 overflow-auto rounded border bg-gray-50 p-2 text-sm whitespace-pre-wrap text-black">
+                    {typeof message.data === "string"
+                      ? message.data
+                      : JSON.stringify(message.data, null, 2)}
+                  </pre>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <button
+            onClick={handleDisconnect}
+            className="transition-colorsf mb-4 cursor-pointer rounded bg-red-600 px-3 py-2 text-white hover:bg-red-700"
+          >
+            Disconnect
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/sse/route.ts
+++ b/src/app/api/sse/route.ts
@@ -1,0 +1,7 @@
+import { sseManager } from "@/lib/sse";
+
+function encodeSSE(event: string, data: any) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export { encodeSSE };

--- a/src/app/api/sse/send/route.ts
+++ b/src/app/api/sse/send/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { sseManager } from "@/lib/sse";
+import { logToFile } from "@/lib/sse/logger";
+
+export async function POST(req: NextRequest) {
+  const { targetId, eventName, payload } = await req.json();
+  try {
+    if (eventName === "broadcast") {
+      sseManager.broadcast(eventName || "broadcast", {
+        event: eventName || "broadcast",
+        payload,
+      });
+    } else {
+      sseManager.sendEvent(targetId, "message", {
+        event: eventName || "message",
+        payload,
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    logToFile(`ERROR Sending ${eventName || "message"}: ${String(err)}`);
+  }
+}

--- a/src/app/api/sse/stream/route.ts
+++ b/src/app/api/sse/stream/route.ts
@@ -1,0 +1,53 @@
+import type { NextRequest } from "next/server";
+
+import { sseManager } from "@/lib/sse";
+import type { Client } from "@/lib/sse/types";
+import { encodeSSE } from "../route";
+import { logToFile } from "@/lib/sse/logger";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const clientId = searchParams.get("id") || crypto.randomUUID();
+  const userId = searchParams.get("userId") || undefined;
+  const name = searchParams.get("name") || `Session-${clientId}`;
+
+  const stream = new TransformStream();
+  const writer = stream.writable.getWriter();
+
+  const client: Client = {
+    id: clientId,
+    name,
+    userId,
+    res: writer,
+    status: "connected",
+    subscriptions: new Set(),
+  };
+
+  sseManager.addClient(client);
+
+  req.signal.addEventListener("abort", async () => {
+    sseManager.removeClient(clientId);
+    logToFile(`DISCONNECTED: ${client.name} (${client.id})`);
+  });
+
+  try {
+    writer.write(
+      encodeSSE("message", {
+        event: "connect",
+        payload: "Connected to event stream!",
+      }),
+    );
+  } catch (err) {
+    logToFile(
+      `ERROR on connect for ${client.name} (${client.id}): ${String(err)}`,
+    );
+  }
+
+  return new Response(stream.readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from "@prisma/client";
+import { sseManager } from "@/lib/sse";
+
+const prisma = new PrismaClient();
+
+export async function GET() {
+  const activeUserIds = sseManager.getActiveUsers();
+
+  const users = await prisma.user.findMany({
+    select: { id: true, name: true },
+  });
+
+  const usersWithStatus = users.map((user) => ({
+    ...user,
+    is_connected: activeUserIds.some(
+      (activeUser) => activeUser.userId === user.id,
+    ),
+  }));
+
+  return new Response(JSON.stringify(usersWithStatus), { status: 200 });
+}

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -31,6 +31,8 @@ export const paths = {
   landingPage: "/",
   homePage: "/home",
   reelsUploadPage: "/reels/upload",
+  broadcastPage: "/broadcast-panel",
+  eventSubscriberPage: "/subscriber-panel",
 } as const;
 
 // ⚠️ DEFINE METADATA FOR NEW ROUTES HERE ⚠️
@@ -49,6 +51,16 @@ export const routes: Record<keyof typeof paths, RouteData> = {
   reelsUploadPage: {
     name: "Reels Upload Page",
     path: paths.reelsUploadPage,
+    accessType: "protected",
+  },
+  broadcastPage: {
+    name: "Broadcast Page",
+    path: paths.broadcastPage,
+    accessType: "protected",
+  },
+  eventSubscriberPage: {
+    name: "Event Subscriber Page",
+    path: paths.eventSubscriberPage,
     accessType: "protected",
   },
 };

--- a/src/features/home/components/WelcomeMessage.tsx
+++ b/src/features/home/components/WelcomeMessage.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Button } from "@/shared/components/ui/button";
 
 const WelcomeMessage = ({
@@ -14,6 +15,19 @@ const WelcomeMessage = ({
       </h1>
       <div className="flex flex-col items-center gap-2">
         <Button onClick={signOut}>{"Sign out"}</Button>
+      </div>
+
+      <div className="mt-5 flex flex-col items-center gap-2">
+        <Link href="/broadcast-panel">
+          <Button variant="secondary" className="w-full">
+            Broadcast Event
+          </Button>
+        </Link>
+        <Link href="/subscriber-panel">
+          <Button variant="secondary" className="w-full">
+            Go to Event
+          </Button>
+        </Link>
       </div>
     </>
   );

--- a/src/hooks/useSSEControl.ts
+++ b/src/hooks/useSSEControl.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRef, useCallback, useState } from "react";
+import { getSession } from "next-auth/react";
+
+type EventHandler<T> = (data: T, event: MessageEvent) => void;
+
+export function useSSEControl<T = any>(
+  eventNames: string | string[],
+  onEvent: EventHandler<T>,
+) {
+  const esRef = useRef<EventSource | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  const connect = useCallback(async () => {
+    if (esRef.current) return;
+
+    const session = await getSession();
+    if (!session?.user) {
+      console.warn("No session found, cannot connect to SSE.");
+      return;
+    }
+
+    const events = Array.isArray(eventNames) ? eventNames : [eventNames];
+    const url = `/api/sse/stream?userId=${session.user.id}&name=${session.user.name}`;
+    const es = new EventSource(url, { withCredentials: true });
+
+    const handler = (event: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(event.data);
+        onEvent(parsed, event);
+      } catch {
+        onEvent(event.data as unknown as T, event);
+      }
+    };
+
+    events.forEach((name) => es.addEventListener(name, handler));
+    es.onerror = (err) => console.error("SSE connection error:", err);
+
+    esRef.current = es;
+    setConnected(true);
+  }, [eventNames, onEvent]);
+
+  const disconnect = useCallback(() => {
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+      setConnected(false);
+    }
+  }, []);
+
+  return { connect, disconnect, connected };
+}

--- a/src/lib/sse/index.ts
+++ b/src/lib/sse/index.ts
@@ -1,0 +1,61 @@
+import { logToFile } from "./logger";
+import type { Client } from "./types";
+
+class SSEManager {
+  public clients: Map<string, Client> = new Map();
+  private heartbeatInterval: NodeJS.Timeout | null = null;
+  public instanceId: string;
+
+  constructor() {
+    this.startHeartbeat();
+    this.instanceId = crypto.randomUUID();
+  }
+
+  private startHeartbeat() {
+    this.heartbeatInterval = setInterval(() => {
+      this.broadcast("ping", { event: "ping", payload: "Heartbeat" });
+    }, 25000);
+  }
+
+  public addClient(client: Client) {
+    this.clients.set(client.userId || client.id, client);
+    logToFile(`CONNECTED: ${client.name} (${client.id})`);
+  }
+
+  public removeClient(id: string) {
+    const client = this.clients.get(id);
+    try {
+      if (client && this.clients.delete(id)) {
+      }
+    } catch (err) {
+      logToFile(
+        `ERROR on disconnect for ${client?.name} (${client?.id}): ${String(err)}`,
+      );
+    }
+  }
+
+  public sendEvent(clientId: string, event: string, data: unknown) {
+    const client = this.clients.get(clientId);
+    if (!client) return;
+    client.res.write(`event: ${event}\n`);
+    client.res.write(`data: ${JSON.stringify(data)}\n\n`);
+  }
+
+  public broadcast(event: string, data: unknown) {
+    for (const client of this.clients.values()) {
+      client.res.write(`event: ${event}\n`);
+      client.res.write(`data: ${JSON.stringify(data)}\n\n`);
+    }
+  }
+
+  public getActiveUsers() {
+    return Array.from(this.clients.values()).map(({ id, userId, name }) => ({
+      id,
+      userId,
+      name,
+      status: "connected",
+    }));
+  }
+}
+
+export const sseManager = new SSEManager();

--- a/src/lib/sse/logger.ts
+++ b/src/lib/sse/logger.ts
@@ -1,0 +1,13 @@
+import path from "path";
+import fs from "fs";
+
+const logDir = path.join(process.cwd(), "logs");
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir, { recursive: true });
+}
+const logFile = path.join(logDir, "connections.log");
+
+export function logToFile(message: string) {
+  const timestamp = new Date().toISOString();
+  fs.appendFileSync(logFile, `[${timestamp}] ${message}\n`);
+}

--- a/src/lib/sse/types.ts
+++ b/src/lib/sse/types.ts
@@ -1,0 +1,8 @@
+export type Client = {
+  id: string;
+  name: string;
+  userId?: string;
+  res: WritableStreamDefaultWriter;
+  status: "connected" | "disconnected";
+  subscriptions: Set<string>;
+};


### PR DESCRIPTION
This PR adds Server-Sent Events (SSE) support to enable clients to subscribe and receive real-time events pushed from the server.


Features implemented:

- Clients can connect to `/api/sse/stream` endpoint and receive server updates in real time.
- Support for sending **arbitrary named events** with **JSON payloads** to individual or multiple connected clients.
- Connection lifecycle logging (connect, disconnect, error) into `logs/connections.log`.
- Graceful handling of client disconnections.
- SSE headers set to ensure proper event streaming and prevent caching.


### Changes Made

1. Frontend Updates
    - BroadcastPanel: Displays user list with online/offline status in dropdown.
    - SubscriberPanel: Shows received events (message, ping, broadcast) in real time.
    
2.  Backend Integration
    - Centralized SSE manager to maintain active client connection lifecycle.
    - Clients are identified by `userId` if provided, otherwise by `client.id`.
    - Heartbeat ensures connection remains open and is monitored.
    - Disconnections are handled in `req.signal.addEventListener("abort")`.
    
3. Client Management
    - Maintains a list of connected clients.
    - Supports sending messages to:
        - A single client by `id`
        - Broadcast to all connected clients
        
4. Robust Error Handling & Logging
    - All SSE connect/disconnect, broadcast, and send actions are wrapped with `try/catch` and logged using `logToFile`.
    - Logs:
        - New connections with timestamp & client ID
        - Disconnections with timestamp & client ID
        - Errors during connection/disconnection
        
5. API Enhancements
    - `GET /api/sse/stream` now returns correct connection stream and cleans up on client abort.
    - `POST /api/sse/send` supports targeted user messages or global broadcast.
    - `GET /api/users` to fetch all user’s with connectivity status.
    


### Additional Notes
- SSE keeps a single HTTP connection open for each client — efficient for server → client push.
- Heartbeats (`ping`) are sent every 25 seconds to prevent timeouts and detect dead connections.
- Log file grows over time; consider log rotation for production.


### Preview
[screenrecord.webm](https://github.com/user-attachments/assets/1003df70-d251-407d-ac48-ef378985eb25)
